### PR TITLE
fix(docs): 修正 core standards 計數並補建 SPEC-CLI-AGENTS-MD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document defines the development standards for the Universal Development St
 
 Universal Development Standards is a language-agnostic, framework-agnostic development standards framework. It provides:
 
-- **Core Standards** (`core/`): 50 fundamental development standards
+- **Core Standards** (`core/`): 48 fundamental development standards
 - **AI Skills** (`skills/`): Claude Code skills for AI-assisted development
 - **CLI Tool** (`cli/`): Node.js CLI for adopting standards
 - **Integrations** (`integrations/`): Configurations for various AI tools
@@ -457,7 +457,7 @@ UDS (標準定義) ──→ DevAP (編排執行) ──→ VibeOps (全生命�
 
 ### UDS 的角色
 
-1. **標準來源**：UDS 定義的 50 項標準被 DevAP 和 VibeOps 消費
+1. **標準來源**：UDS 定義的 48 項標準被 DevAP 和 VibeOps 消費
 2. **工具無關**：UDS 支援 9 種 AI 工具，DevAP/VibeOps 只是消費者之一
 3. **授權隔離**：UDS 的 MIT + CC BY 4.0 授權不受消費者的 AGPL/Apache 影響
 
@@ -505,7 +505,7 @@ UDS (標準定義) ──→ DevAP (編排執行) ──→ VibeOps (全生命�
 
 本專案採用 UDS 標準。所有規範位於 `.standards/`：
 
-### Core (50 standards)
+### Core (48 standards)
 - `anti-hallucination.ai.yaml` - anti-hallucination.ai.yaml
 - `ai-friendly-architecture.ai.yaml` - ai-friendly-architecture.ai.yaml
 - `commit-message.ai.yaml` - 提交訊息格式
@@ -949,7 +949,7 @@ AI:
 
 ```
 universal-dev-standards/
-├── core/                  # Core standards (50 files)
+├── core/                  # Core standards (48 files)
 ├── skills/                # AI tool skills
 │   └── claude-code/       # Claude Code skills (26 skills)
 ├── cli/                   # Node.js CLI tool

--- a/docs/specs/cli/init/SPEC-CLI-AGENTS-MD.md
+++ b/docs/specs/cli/init/SPEC-CLI-AGENTS-MD.md
@@ -1,0 +1,70 @@
+# SPEC-CLI-AGENTS-MD: AGENTS.md 通用輸出整合
+
+> **Status**: Implemented
+> **Author**: AI Assistant (Claude Opus 4.6)
+> **Date**: 2026-03-20
+> **PR**: #38
+> **Type**: Feature Enhancement
+> **Scope**: partial (UDS CLI 功能，但概念通用)
+
+## Context
+
+AGENTS.md 已成為 Linux Foundation 下 AAIF 管理的開放標準，60K+ 開源專案採用，所有主流 AI 工具原生支援。
+
+UDS 原本僅在選擇 codex/opencode 時生成 AGENTS.md。此 Spec 新增「通用輸出」功能，無論選擇哪些工具都可額外生成。
+
+## Problem Statement
+
+| 面向 | 說明 |
+|------|------|
+| **當前行為** | AGENTS.md 僅在選擇 codex 或 opencode 時生成 |
+| **期望行為** | 無論選擇哪些工具，都可選擇額外生成 AGENTS.md 作為通用格式 |
+| **缺口** | 選擇 claude-code + cursor 的用戶無法獲得 AGENTS.md |
+
+## Requirements
+
+| ID | 描述 | 狀態 |
+|----|------|------|
+| REQ-001 | `uds init` 時提供 AGENTS.md 生成選項 | ✅ |
+| REQ-002 | AGENTS.md 內容為精簡摘要（≤ 150 行） | ✅ |
+| REQ-003 | 若已選 codex/opencode，不重複生成 | ✅ |
+| REQ-004 | `uds update` 時同步更新 AGENTS.md | ✅ |
+| REQ-005 | 內容指向 `.standards/` 取得完整標準 | ✅ |
+| REQ-006 | 支援 `--agents-md` / `--no-agents-md` CLI flag | ✅ |
+
+## Implementation
+
+### 修改的檔案
+
+| 檔案 | 變更 |
+|------|------|
+| `cli/bin/uds.js` | `--agents-md` / `--no-agents-md` flags |
+| `cli/src/utils/integration-generator.js` | `generateAgentsMdSummary()`, `writeAgentsMdSummary()`, `detectBuildCommands()` |
+| `cli/src/prompts/init.js` | `promptAgentsMd()` |
+| `cli/src/flows/init-flow.js` | Step 3.5 AGENTS.md 提示 |
+| `cli/src/commands/init.js` | 非互動模式 + 安裝步驟 2.5 |
+| `cli/src/commands/update.js` | update + regenerateIntegrations 支援 |
+| `cli/src/commands/config.js` | AI 工具變更時提示 |
+| `cli/src/installers/integration-installer.js` | `generateUniversalAgentsMd()` |
+| `cli/src/installers/manifest-installer.js` | `generateAgentsMd` 欄位 |
+| `cli/src/i18n/messages.js` | 英文/繁中/簡中 i18n |
+| `cli/src/core/constants.js` | `AGENTS_MD_UNIVERSAL` 常數 |
+
+### 測試覆蓋
+
+- 單元測試：12 個（`generateAgentsMdSummary` 輸出驗證）
+- 整合測試：5 個（`generateUniversalAgentsMd` 去重邏輯）
+- E2E 測試：4 個（完整 init 流程）
+
+## Cross-Project Issues
+
+| 專案 | Issue | 說明 |
+|------|-------|------|
+| DevAP | AsiaOstrich/dev-autopilot#1 | QualityGate + drift 偵測 |
+| VibeOps | AsiaOstrich/vibeops#18 | Agent prompt 引用 |
+
+## Version History
+
+| 版本 | 日期 | 說明 |
+|------|------|------|
+| 1.0 | 2026-03-20 | Implemented — PR #38 merged |

--- a/locales/zh-CN/CLAUDE.md
+++ b/locales/zh-CN/CLAUDE.md
@@ -14,7 +14,7 @@ status: current
 
 Universal Development Standards 是一个语言无关、框架无关的文件化标准框架。它提供：
 
-- **核心规范** (`core/`)：50 个基础开发标准
+- **核心规范** (`core/`)：48 个基础开发标准
 - **AI 技能** (`skills/`)：用于 AI 辅助开发的 Claude Code 技能
 - **CLI 工具** (`cli/`)：用于采用标准的 Node.js CLI
 - **整合** (`integrations/`)：各种 AI 工具的配置
@@ -200,7 +200,7 @@ node cli\bin\uds.js init --help
 
 ```
 universal-dev-standards/
-├── core/                  # 核心规范（50 个档案）
+├── core/                  # 核心规范（48 个档案）
 ├── skills/                # AI 工具技能
 │   └── claude-code/       # Claude Code 技能（26 个技能）
 ├── cli/                   # Node.js CLI 工具

--- a/locales/zh-TW/CLAUDE.md
+++ b/locales/zh-TW/CLAUDE.md
@@ -14,7 +14,7 @@ status: current
 
 Universal Development Standards 是一個語言無關、框架無關的文件化標準框架。它提供：
 
-- **核心規範** (`core/`)：50 個基礎開發標準
+- **核心規範** (`core/`)：48 個基礎開發標準
 - **AI 技能** (`skills/`)：用於 AI 輔助開發的 Claude Code 技能
 - **CLI 工具** (`cli/`)：用於採用標準的 Node.js CLI
 - **整合** (`integrations/`)：各種 AI 工具的配置
@@ -200,7 +200,7 @@ node cli\bin\uds.js init --help
 
 ```
 universal-dev-standards/
-├── core/                  # 核心規範（50 個檔案）
+├── core/                  # 核心規範（48 個檔案）
 ├── skills/                # AI 工具技能
 │   └── claude-code/       # Claude Code 技能（26 個技能）
 ├── cli/                   # Node.js CLI 工具


### PR DESCRIPTION
## Summary

- 修正 CLAUDE.md 及翻譯檔的 core standards 計數（50→48）
- 追溯建立 `SPEC-CLI-AGENTS-MD` 規格文件（PR #38 的規格追蹤）

## Test Plan

- [x] `check-docs-integrity.sh` 通過（core standards count 正確）
- [x] 1578 unit tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)