### PR TITLE
feat(cli): 新增 AGENTS.md 標準同步檢查並更新 usage docs

### DIFF
--- a/cli/src/commands/check.js
+++ b/cli/src/commands/check.js
@@ -345,6 +345,9 @@ export async function checkCommand(options = {}) {
   // Integration files check
   checkIntegrationFiles(manifest, projectPath, msg);
 
+  // Universal AGENTS.md sync check
+  checkAgentsMdSync(manifest, projectPath, msg);
+
   // Skills status
   const { missingSkills, missingCommands } = displaySkillsStatus(manifest, projectPath, msg);
 
@@ -1038,6 +1041,70 @@ function checkIntegrationFiles(manifest, projectPath, msg) {
     console.log(chalk.yellow(`  ${msg.toFixIntegration}`));
     console.log(chalk.gray(`    ${msg.runUpdateToSync}`));
     console.log(chalk.gray(`    ${msg.runConfigureTools}`));
+  }
+
+  console.log();
+}
+
+/**
+ * Check universal AGENTS.md sync with installed standards
+ * Verifies the standards listed in AGENTS.md match the manifest
+ */
+function checkAgentsMdSync(manifest, projectPath, msg) {
+  // Skip if generateAgentsMd is not enabled
+  if (!manifest.generateAgentsMd) {
+    return;
+  }
+
+  // Skip if codex/opencode already handles AGENTS.md
+  const hasAgentsMdTool = (manifest.aiTools || []).some(t => t === 'codex' || t === 'opencode');
+  if (hasAgentsMdTool) {
+    return;
+  }
+
+  const agentsMdPath = join(projectPath, 'AGENTS.md');
+
+  console.log(chalk.cyan(msg.agentsMdSyncCheck || 'AGENTS.md Standards Sync'));
+
+  if (!existsSync(agentsMdPath)) {
+    console.log(chalk.red(`  ✗ AGENTS.md ${msg.missing || 'missing'}`));
+    console.log(chalk.gray(`    ${msg.runUpdateToRestore || 'Run "uds update" to restore'}`));
+    console.log();
+    return;
+  }
+
+  const content = readFileSync(agentsMdPath, 'utf-8');
+  const installedStandards = (manifest.standards || []).map(s => basename(s));
+
+  // Check standards listed in AGENTS.md vs manifest
+  const aiYamlStandards = installedStandards.filter(s => s.endsWith('.ai.yaml'));
+  let listedCount = 0;
+  let missingFromAgentsMd = [];
+
+  for (const std of aiYamlStandards) {
+    if (content.includes(std)) {
+      listedCount++;
+    } else {
+      missingFromAgentsMd.push(std);
+    }
+  }
+
+  if (missingFromAgentsMd.length === 0) {
+    console.log(chalk.green(`  ✓ AGENTS.md ${msg.standardsSynced || 'standards synced'} (${listedCount}/${aiYamlStandards.length})`));
+  } else {
+    console.log(chalk.yellow(`  ⚠ AGENTS.md ${msg.standardsOutOfSync || 'standards out of sync'} (${listedCount}/${aiYamlStandards.length})`));
+    if (missingFromAgentsMd.length <= 5) {
+      console.log(chalk.gray(`    ${msg.missingInAgentsMd || 'Missing'}: ${missingFromAgentsMd.join(', ')}`));
+    } else {
+      console.log(chalk.gray(`    ${msg.missingInAgentsMd || 'Missing'}: ${missingFromAgentsMd.slice(0, 5).join(', ')}... (+${missingFromAgentsMd.length - 5})`));
+    }
+    console.log(chalk.gray(`    ${msg.runUpdateToSync || 'Run "uds update" to sync'}`));
+  }
+
+  // Check line count
+  const lineCount = content.split('\n').length;
+  if (lineCount > 150) {
+    console.log(chalk.yellow(`  ⚠ AGENTS.md ${msg.exceedsLineLimit || 'exceeds 150 line limit'} (${lineCount} lines)`));
   }
 
   console.log();

--- a/docs/CHEATSHEET.md
+++ b/docs/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UDS Cheatsheet
 
-> Quick reference for all UDS features | Last updated: 2026-03-17
+> Quick reference for all UDS features | Last updated: 2026-03-20
 
 **Language**: English | [繁體中文](../locales/zh-TW/docs/CHEATSHEET.md) | [简体中文](../locales/zh-CN/docs/CHEATSHEET.md)
 
@@ -24,6 +24,7 @@
 
 | Command | Description |
 |---------|-------------|
+| `/ac-coverage` | "[UDS] Generate AC-to-test traceability matrix and coverage report" |
 | `/atdd` | [UDS] Guide through Acceptance Test-Driven Development workflow |
 | `/bdd` | [UDS] Guide through Behavior-Driven Development workflow |
 | `/brainstorm` | "[UDS] Structured AI-assisted brainstorming before spec creation" |
@@ -62,6 +63,7 @@
 
 | Skill | Description |
 |-------|-------------|
+| `ac-coverage-assistant` | "[UDS] Analyze AC-to-test traceability and coverage" |
 | `ai-collaboration-standards` | Prevent AI hallucination and ensure evidence-based responses |
 | `ai-friendly-architecture` | Design AI-friendly architecture with explicit patterns, laye |
 | `ai-instruction-standards` | Create and maintain AI instruction files (CLAUDE.md, .cursor |
@@ -116,18 +118,24 @@
 
 | Standard | Description |
 |----------|-------------|
+| `acceptance-criteria-traceability` | Acceptance Criteria Traceability Standards |
 | `acceptance-test-driven-development` | Acceptance Test-Driven Development (ATDD) Standards |
 | `accessibility-standards` | This standard defines comprehensive guidelines for |
+| `agent-dispatch` | Define standards for dispatching AI sub-agents in  |
 | `ai-agreement-standards` | This standard formalizes the interaction between H |
 | `ai-friendly-architecture` | This standard defines architecture and documentati |
 | `ai-instruction-standards` | This standard defines best practices for creating  |
 | `anti-hallucination` | This standard defines strict guidelines for AI ass |
+| `api-design-standards` | This standard defines comprehensive guidelines for |
 | `behavior-driven-development` | Behavior-Driven Development (BDD) Standards |
+| `branch-completion` | Define a standardized workflow for completing deve |
+| `change-batching-standards` | Change Batching Standards |
 | `changelog-standards` | This standard defines how to write and maintain a  |
 | `checkin-standards` | This standard defines quality gates that MUST be p |
 | `code-review-checklist` | This standard provides a comprehensive checklist f |
 | `commit-message-guide` | Standardized commit messages improve code review e |
 | `context-aware-loading` | This standard defines a protocol for AI tools to s |
+| `database-standards` | This standard defines guidelines for database desi |
 | `deployment-standards` | This standard defines guidelines for safely deploy |
 | `developer-memory` | This standard defines a structured system for capt |
 | `documentation-structure` | This standard defines a consistent documentation s |
@@ -135,8 +143,11 @@
 | `error-code-standards` | Error Code Standards |
 | `forward-derivation-standards` | This standard defines the principles and workflows |
 | `git-workflow` | This standard defines Git branching strategies and |
+| `git-worktree` | Define a lifecycle for using Git worktrees to isol |
 | `logging-standards` | Logging Standards |
+| `model-selection` | Define a cost-effective strategy for selecting AI  |
 | `performance-standards` | This standard defines comprehensive guidelines for |
+| `pipeline-integration-standards` | Pipeline Integration Standards |
 | `project-context-memory` | This standard defines a structured system for capt |
 | `project-structure` | This standard defines conventions for project dire |
 | `refactoring-standards` | This standard defines comprehensive guidelines for |
@@ -145,12 +156,15 @@
 | `security-standards` | This standard defines comprehensive security guide |
 | `spec-driven-development` | Spec-Driven Development (SDD) Standards |
 | `structured-task-definition` | Structured Task Definition Standards |
+| `systematic-debugging` | Define a structured, four-phase debugging workflow |
 | `test-completeness-dimensions` | This document defines a systematic framework for e |
 | `test-driven-development` | Test-Driven Development (TDD) Standards |
 | `test-governance` | Test Governance Standards |
 | `testing-standards` | This standard defines actionable testing rules and |
+| `verification-evidence` | Establish an "Iron Law" that no task can be claime |
 | `versioning` | This standard defines how to version software rele |
 | `virtual-organization-standards` | This standard treats the AI ecosystem as a "Virtua |
+| `workflow-enforcement` | Workflow Enforcement Standards |
 | `workflow-state-protocol` | Workflow State Protocol |
 
 ## 📜 Scripts
@@ -164,6 +178,7 @@
 | `check-cli-docs-sync.sh` | CLI-to-Documentation Sync Checker |
 | `check-commands-sync.ps1` | Check Commands Sync |
 | `check-commands-sync.sh` | Commands Sync Checker |
+| `check-commit-spec-reference.sh` | Commit-msg Spec Reference Suggestion — WARNING ONL |
 | `check-docs-integrity.ps1` | Check Docs Integrity |
 | `check-docs-integrity.sh` | Documentation Integrity Checker |
 | `check-docs-sync.ps1` | Check Docs Sync |
@@ -186,6 +201,7 @@
 | `check-usage-docs-sync.sh` | check-usage-docs-sync.sh |
 | `check-version-sync.ps1` | Check Version Sync |
 | `check-version-sync.sh` | Version Sync Checker |
+| `check-workflow-compliance.sh` | Workflow Compliance Check — WARNING ONLY (non-bloc |
 | `convert-md-to-yaml.mjs` | Markdown to AI-YAML Conversion Script |
 | `fix-manifest-paths.ps1` | Fix Manifest Paths |
 | `fix-manifest-paths.sh` | Manifest Path Fixer |

--- a/docs/FEATURE-REFERENCE.md
+++ b/docs/FEATURE-REFERENCE.md
@@ -1,7 +1,7 @@
 # UDS Feature Reference
 
 > Universal Development Standards - Complete Feature Documentation
-> Auto-generated | Last updated: 2026-03-17
+> Auto-generated | Last updated: 2026-03-20
 
 **Language**: English | [繁體中文](../locales/zh-TW/docs/FEATURE-REFERENCE.md) | [简体中文](../locales/zh-CN/docs/FEATURE-REFERENCE.md)
 
@@ -10,14 +10,14 @@
 ## Table of Contents
 
 1. [CLI Commands](#cli-commands) (9)
-2. [Slash Commands](#slash-commands) (33)
-3. [Skills](#skills) (29)
+2. [Slash Commands](#slash-commands) (34)
+3. [Skills](#skills) (30)
 4. [Agents](#agents) (5)
 5. [Workflows](#workflows) (5)
-6. [Core Standards](#core-standards) (36)
-7. [Scripts](#scripts) (39)
+6. [Core Standards](#core-standards) (48)
+7. [Scripts](#scripts) (41)
 
-**Total Features: 156**
+**Total Features: 172**
 
 ---
 
@@ -50,6 +50,8 @@
 | `--locale` | Locale extension (zh-tw) |
 | `--skills-location` | Skills location (marketplace, user, project, none) [default: marketplace] |
 | `--content-mode` | Content mode for integration files (minimal, index, full) [default: index] |
+| `--agents-md` | Generate AGENTS.md universal summary |
+| `--no-agents-md` | Skip AGENTS.md generation |
 | `-y, --yes` | Use defaults, skip interactive prompts |
 | `-E, --experimental` | Enable experimental features (methodology) |
 
@@ -148,6 +150,7 @@
 
 | Command | Description |
 |---------|-------------|
+| `/ac-coverage` | "[UDS] Generate AC-to-test traceability matrix and coverage report" |
 | `/atdd` | [UDS] Guide through Acceptance Test-Driven Development workflow |
 | `/bdd` | [UDS] Guide through Behavior-Driven Development workflow |
 | `/brainstorm` | "[UDS] Structured AI-assisted brainstorming before spec creation" |
@@ -188,6 +191,7 @@
 
 | Skill | Description |
 |-------|-------------|
+| `ac-coverage-assistant` | "[UDS] Analyze AC-to-test traceability and coverage" |
 | `ai-collaboration-standards` | Prevent AI hallucination and ensure evidence-based responses when analyzing code or making suggestions. |
 | `ai-friendly-architecture` | Design AI-friendly architecture with explicit patterns, layered documentation, and semantic boundaries. |
 | `ai-instruction-standards` | Create and maintain AI instruction files (CLAUDE.md, .cursorrules, etc.) with proper structure. |
@@ -248,27 +252,36 @@
 
 | Standard | Version | Description |
 |----------|---------|-------------|
+| `acceptance-criteria-traceability` | - |  |
 | `acceptance-test-driven-development` | 1.1.0 |  |
 | `accessibility-standards` | 1.0.0 | This standard defines comprehensive guidelines for creating accessible software  |
+| `agent-dispatch` | 1.0.0 | Define standards for dispatching AI sub-agents in parallel, coordinating their w |
 | `ai-agreement-standards` | 1.0.0 | This standard formalizes the interaction between Human (Acquirer) and AI (Suppli |
 | `ai-friendly-architecture` | 1.0.0 | This standard defines architecture and documentation practices that maximize the |
 | `ai-instruction-standards` | 1.0.0 | This standard defines best practices for creating and maintaining AI instruction |
 | `anti-hallucination` | 1.5.0 | This standard defines strict guidelines for AI assistants to prevent hallucinati |
+| `api-design-standards` | 1.0.0 | This standard defines comprehensive guidelines for designing, building, and main |
 | `behavior-driven-development` | 1.1.0 |  |
+| `branch-completion` | 1.0.0 | Define a standardized workflow for completing development branches, including pr |
+| `change-batching-standards` | - |  |
 | `changelog-standards` | 1.0.2 | This standard defines how to write and maintain a CHANGELOG.md file to communica |
-| `checkin-standards` | 1.4.0 | This standard defines quality gates that MUST be passed before committing code t |
+| `checkin-standards` | 1.5.0 | This standard defines quality gates that MUST be passed before committing code t |
 | `code-review-checklist` | 1.3.0 | This standard provides a comprehensive checklist for reviewing code changes, ens |
 | `commit-message-guide` | 1.3.0 | Standardized commit messages improve code review efficiency, facilitate automate |
 | `context-aware-loading` | 1.0.0 | This standard defines a protocol for AI tools to selectively load development st |
+| `database-standards` | 1.0.0 | This standard defines guidelines for database design, querying, migration, and o |
 | `deployment-standards` | 1.0.0 | This standard defines guidelines for safely deploying software to production, co |
 | `developer-memory` | 1.0.0 | This standard defines a structured system for capturing, retrieving, and surfaci |
 | `documentation-structure` | 1.5.0 | This standard defines a consistent documentation structure for software projects |
 | `documentation-writing-standards` | 1.2.0 | This standard defines documentation requirements based on project types and prov |
-| `error-code-standards` | 1.1.0 |  |
-| `forward-derivation-standards` | 1.1.0 | This standard defines the principles and workflows for Forward Derivation—automa |
+| `error-code-standards` | 1.2.0 |  |
+| `forward-derivation-standards` | 1.2.0 | This standard defines the principles and workflows for Forward Derivation—automa |
 | `git-workflow` | 1.4.0 | This standard defines Git branching strategies and workflows to ensure consisten |
+| `git-worktree` | 1.0.0 | Define a lifecycle for using Git worktrees to isolate development work, ensuring |
 | `logging-standards` | 1.2.0 |  |
+| `model-selection` | 1.0.0 | Define a cost-effective strategy for selecting AI model tiers based on task comp |
 | `performance-standards` | 1.1.0 | This standard defines comprehensive guidelines for software performance engineer |
+| `pipeline-integration-standards` | - |  |
 | `project-context-memory` | 1.1.0 | This standard defines a structured system for capturing, retrieving, and enforci |
 | `project-structure` | 1.2.0 | This standard defines conventions for project directory structure beyond documen |
 | `refactoring-standards` | 2.1.0 | This standard defines comprehensive guidelines for code refactoring, covering ev |
@@ -277,12 +290,15 @@
 | `security-standards` | 1.1.0 | This standard defines comprehensive security guidelines for software development |
 | `spec-driven-development` | 2.1.0 |  |
 | `structured-task-definition` | 1.0.0 |  |
+| `systematic-debugging` | 1.0.0 | Define a structured, four-phase debugging workflow that prevents the common anti |
 | `test-completeness-dimensions` | 1.1.0 | This document defines a systematic framework for evaluating test completeness. I |
 | `test-driven-development` | 1.2.0 |  |
 | `test-governance` | - |  |
 | `testing-standards` | 3.0.0 | This standard defines actionable testing rules and conventions for AI agents and |
+| `verification-evidence` | 1.0.0 | Establish an "Iron Law" that no task can be claimed as complete without verifica |
 | `versioning` | 1.2.0 | This standard defines how to version software releases using Semantic Versioning |
 | `virtual-organization-standards` | 1.0.0 | This standard treats the AI ecosystem as a "Virtual Organization." It defines ho |
+| `workflow-enforcement` | - |  |
 | `workflow-state-protocol` | 1.0.0 |  |
 
 ---
@@ -298,6 +314,7 @@
 | `check-cli-docs-sync.sh` | CLI-to-Documentation Sync Checker |
 | `check-commands-sync.ps1` | Check Commands Sync |
 | `check-commands-sync.sh` | Commands Sync Checker |
+| `check-commit-spec-reference.sh` | Commit-msg Spec Reference Suggestion — WARNING ONLY (non-blocking) |
 | `check-docs-integrity.ps1` | Check Docs Integrity |
 | `check-docs-integrity.sh` | Documentation Integrity Checker |
 | `check-docs-sync.ps1` | Check Docs Sync |
@@ -320,6 +337,7 @@
 | `check-usage-docs-sync.sh` | check-usage-docs-sync.sh |
 | `check-version-sync.ps1` | Check Version Sync |
 | `check-version-sync.sh` | Version Sync Checker |
+| `check-workflow-compliance.sh` | Workflow Compliance Check — WARNING ONLY (non-blocking) |
 | `convert-md-to-yaml.mjs` | Markdown to AI-YAML Conversion Script |
 | `fix-manifest-paths.ps1` | Fix Manifest Paths |
 | `fix-manifest-paths.sh` | Manifest Path Fixer |

--- a/locales/zh-CN/docs/CHEATSHEET.md
+++ b/locales/zh-CN/docs/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UDS 速查表
 
-> Quick reference for all UDS features | Last updated: 2026-03-17
+> Quick reference for all UDS features | Last updated: 2026-03-20
 
 **Language**: [English](../../../docs/CHEATSHEET.md) | [繁體中文](../../zh-TW/docs/CHEATSHEET.md) | 简体中文
 
@@ -24,6 +24,7 @@
 
 | Command | 说明 |
 |---------|-------------|
+| `/ac-coverage` | "[UDS] Generate AC-to-test traceability matrix and coverage report" |
 | `/atdd` | [UDS] Guide through Acceptance Test-Driven Development workflow |
 | `/bdd` | [UDS] Guide through Behavior-Driven Development workflow |
 | `/brainstorm` | "[UDS] Structured AI-assisted brainstorming before spec creation" |
@@ -62,6 +63,7 @@
 
 | Skill | 说明 |
 |-------|-------------|
+| `ac-coverage-assistant` | "[UDS] Analyze AC-to-test traceability and coverage" |
 | `ai-collaboration-standards` | Prevent AI hallucination and ensure evidence-based responses |
 | `ai-friendly-architecture` | Design AI-friendly architecture with explicit patterns, laye |
 | `ai-instruction-standards` | Create and maintain AI instruction files (CLAUDE.md, .cursor |
@@ -116,18 +118,24 @@
 
 | Standard | 说明 |
 |----------|-------------|
+| `acceptance-criteria-traceability` | Acceptance Criteria Traceability Standards |
 | `acceptance-test-driven-development` | Acceptance Test-Driven Development (ATDD) Standards |
 | `accessibility-standards` | This standard defines comprehensive guidelines for |
+| `agent-dispatch` | Define standards for dispatching AI sub-agents in  |
 | `ai-agreement-standards` | This standard formalizes the interaction between H |
 | `ai-friendly-architecture` | This standard defines architecture and documentati |
 | `ai-instruction-standards` | This standard defines best practices for creating  |
 | `anti-hallucination` | This standard defines strict guidelines for AI ass |
+| `api-design-standards` | This standard defines comprehensive guidelines for |
 | `behavior-driven-development` | Behavior-Driven Development (BDD) Standards |
+| `branch-completion` | Define a standardized workflow for completing deve |
+| `change-batching-standards` | Change Batching Standards |
 | `changelog-standards` | This standard defines how to write and maintain a  |
 | `checkin-standards` | This standard defines quality gates that MUST be p |
 | `code-review-checklist` | This standard provides a comprehensive checklist f |
 | `commit-message-guide` | Standardized commit messages improve code review e |
 | `context-aware-loading` | This standard defines a protocol for AI tools to s |
+| `database-standards` | This standard defines guidelines for database desi |
 | `deployment-standards` | This standard defines guidelines for safely deploy |
 | `developer-memory` | This standard defines a structured system for capt |
 | `documentation-structure` | This standard defines a consistent documentation s |
@@ -135,8 +143,11 @@
 | `error-code-standards` | Error Code Standards |
 | `forward-derivation-standards` | This standard defines the principles and workflows |
 | `git-workflow` | This standard defines Git branching strategies and |
+| `git-worktree` | Define a lifecycle for using Git worktrees to isol |
 | `logging-standards` | Logging Standards |
+| `model-selection` | Define a cost-effective strategy for selecting AI  |
 | `performance-standards` | This standard defines comprehensive guidelines for |
+| `pipeline-integration-standards` | Pipeline Integration Standards |
 | `project-context-memory` | This standard defines a structured system for capt |
 | `project-structure` | This standard defines conventions for project dire |
 | `refactoring-standards` | This standard defines comprehensive guidelines for |
@@ -145,12 +156,15 @@
 | `security-standards` | This standard defines comprehensive security guide |
 | `spec-driven-development` | Spec-Driven Development (SDD) Standards |
 | `structured-task-definition` | Structured Task Definition Standards |
+| `systematic-debugging` | Define a structured, four-phase debugging workflow |
 | `test-completeness-dimensions` | This document defines a systematic framework for e |
 | `test-driven-development` | Test-Driven Development (TDD) Standards |
 | `test-governance` | Test Governance Standards |
 | `testing-standards` | This standard defines actionable testing rules and |
+| `verification-evidence` | Establish an "Iron Law" that no task can be claime |
 | `versioning` | This standard defines how to version software rele |
 | `virtual-organization-standards` | This standard treats the AI ecosystem as a "Virtua |
+| `workflow-enforcement` | Workflow Enforcement Standards |
 | `workflow-state-protocol` | Workflow State Protocol |
 
 ## 📜 脚本
@@ -164,6 +178,7 @@
 | `check-cli-docs-sync.sh` | CLI-to-Documentation Sync Checker |
 | `check-commands-sync.ps1` | Check Commands Sync |
 | `check-commands-sync.sh` | Commands Sync Checker |
+| `check-commit-spec-reference.sh` | Commit-msg Spec Reference Suggestion — WARNING ONL |
 | `check-docs-integrity.ps1` | Check Docs Integrity |
 | `check-docs-integrity.sh` | Documentation Integrity Checker |
 | `check-docs-sync.ps1` | Check Docs Sync |
@@ -186,6 +201,7 @@
 | `check-usage-docs-sync.sh` | check-usage-docs-sync.sh |
 | `check-version-sync.ps1` | Check Version Sync |
 | `check-version-sync.sh` | Version Sync Checker |
+| `check-workflow-compliance.sh` | Workflow Compliance Check — WARNING ONLY (non-bloc |
 | `convert-md-to-yaml.mjs` | Markdown to AI-YAML Conversion Script |
 | `fix-manifest-paths.ps1` | Fix Manifest Paths |
 | `fix-manifest-paths.sh` | Manifest Path Fixer |

--- a/locales/zh-CN/docs/FEATURE-REFERENCE.md
+++ b/locales/zh-CN/docs/FEATURE-REFERENCE.md
@@ -1,7 +1,7 @@
 # UDS 功能参考手册
 
 > Universal Development Standards - 完整功能文档
-> Auto-generated | Last updated: 2026-03-17
+> Auto-generated | Last updated: 2026-03-20
 
 **Language**: [English](../../../docs/FEATURE-REFERENCE.md) | [繁體中文](../../zh-TW/docs/FEATURE-REFERENCE.md) | 简体中文
 
@@ -10,14 +10,14 @@
 ## 目录
 
 1. [CLI 指令](#cli-commands) (9)
-2. [斜线命令](#slash-commands) (33)
-3. [技能](#skills) (29)
+2. [斜线命令](#slash-commands) (34)
+3. [技能](#skills) (30)
 4. [代理](#agents) (5)
 5. [工作流程](#workflows) (5)
-6. [核心规范](#core-standards) (36)
-7. [脚本](#scripts) (39)
+6. [核心规范](#core-standards) (48)
+7. [脚本](#scripts) (41)
 
-**Total Features: 156**
+**Total Features: 172**
 
 ---
 
@@ -50,6 +50,8 @@
 | `--locale` | Locale extension (zh-tw) |
 | `--skills-location` | Skills location (marketplace, user, project, none) [default: marketplace] |
 | `--content-mode` | Content mode for integration files (minimal, index, full) [default: index] |
+| `--agents-md` | Generate AGENTS.md universal summary |
+| `--no-agents-md` | Skip AGENTS.md generation |
 | `-y, --yes` | Use defaults, skip interactive prompts |
 | `-E, --experimental` | Enable experimental features (methodology) |
 
@@ -148,6 +150,7 @@
 
 | Command | 说明 |
 |---------|-------------|
+| `/ac-coverage` | "[UDS] Generate AC-to-test traceability matrix and coverage report" |
 | `/atdd` | [UDS] Guide through Acceptance Test-Driven Development workflow |
 | `/bdd` | [UDS] Guide through Behavior-Driven Development workflow |
 | `/brainstorm` | "[UDS] Structured AI-assisted brainstorming before spec creation" |
@@ -188,6 +191,7 @@
 
 | Skill | 说明 |
 |-------|-------------|
+| `ac-coverage-assistant` | "[UDS] Analyze AC-to-test traceability and coverage" |
 | `ai-collaboration-standards` | Prevent AI hallucination and ensure evidence-based responses when analyzing code or making suggestions. |
 | `ai-friendly-architecture` | Design AI-friendly architecture with explicit patterns, layered documentation, and semantic boundaries. |
 | `ai-instruction-standards` | Create and maintain AI instruction files (CLAUDE.md, .cursorrules, etc.) with proper structure. |
@@ -248,27 +252,36 @@
 
 | Standard | 版本 | 说明 |
 |----------|---------|-------------|
+| `acceptance-criteria-traceability` | - |  |
 | `acceptance-test-driven-development` | 1.1.0 |  |
 | `accessibility-standards` | 1.0.0 | This standard defines comprehensive guidelines for creating accessible software  |
+| `agent-dispatch` | 1.0.0 | Define standards for dispatching AI sub-agents in parallel, coordinating their w |
 | `ai-agreement-standards` | 1.0.0 | This standard formalizes the interaction between Human (Acquirer) and AI (Suppli |
 | `ai-friendly-architecture` | 1.0.0 | This standard defines architecture and documentation practices that maximize the |
 | `ai-instruction-standards` | 1.0.0 | This standard defines best practices for creating and maintaining AI instruction |
 | `anti-hallucination` | 1.5.0 | This standard defines strict guidelines for AI assistants to prevent hallucinati |
+| `api-design-standards` | 1.0.0 | This standard defines comprehensive guidelines for designing, building, and main |
 | `behavior-driven-development` | 1.1.0 |  |
+| `branch-completion` | 1.0.0 | Define a standardized workflow for completing development branches, including pr |
+| `change-batching-standards` | - |  |
 | `changelog-standards` | 1.0.2 | This standard defines how to write and maintain a CHANGELOG.md file to communica |
-| `checkin-standards` | 1.4.0 | This standard defines quality gates that MUST be passed before committing code t |
+| `checkin-standards` | 1.5.0 | This standard defines quality gates that MUST be passed before committing code t |
 | `code-review-checklist` | 1.3.0 | This standard provides a comprehensive checklist for reviewing code changes, ens |
 | `commit-message-guide` | 1.3.0 | Standardized commit messages improve code review efficiency, facilitate automate |
 | `context-aware-loading` | 1.0.0 | This standard defines a protocol for AI tools to selectively load development st |
+| `database-standards` | 1.0.0 | This standard defines guidelines for database design, querying, migration, and o |
 | `deployment-standards` | 1.0.0 | This standard defines guidelines for safely deploying software to production, co |
 | `developer-memory` | 1.0.0 | This standard defines a structured system for capturing, retrieving, and surfaci |
 | `documentation-structure` | 1.5.0 | This standard defines a consistent documentation structure for software projects |
 | `documentation-writing-standards` | 1.2.0 | This standard defines documentation requirements based on project types and prov |
-| `error-code-standards` | 1.1.0 |  |
-| `forward-derivation-standards` | 1.1.0 | This standard defines the principles and workflows for Forward Derivation—automa |
+| `error-code-standards` | 1.2.0 |  |
+| `forward-derivation-standards` | 1.2.0 | This standard defines the principles and workflows for Forward Derivation—automa |
 | `git-workflow` | 1.4.0 | This standard defines Git branching strategies and workflows to ensure consisten |
+| `git-worktree` | 1.0.0 | Define a lifecycle for using Git worktrees to isolate development work, ensuring |
 | `logging-standards` | 1.2.0 |  |
+| `model-selection` | 1.0.0 | Define a cost-effective strategy for selecting AI model tiers based on task comp |
 | `performance-standards` | 1.1.0 | This standard defines comprehensive guidelines for software performance engineer |
+| `pipeline-integration-standards` | - |  |
 | `project-context-memory` | 1.1.0 | This standard defines a structured system for capturing, retrieving, and enforci |
 | `project-structure` | 1.2.0 | This standard defines conventions for project directory structure beyond documen |
 | `refactoring-standards` | 2.1.0 | This standard defines comprehensive guidelines for code refactoring, covering ev |
@@ -277,12 +290,15 @@
 | `security-standards` | 1.1.0 | This standard defines comprehensive security guidelines for software development |
 | `spec-driven-development` | 2.1.0 |  |
 | `structured-task-definition` | 1.0.0 |  |
+| `systematic-debugging` | 1.0.0 | Define a structured, four-phase debugging workflow that prevents the common anti |
 | `test-completeness-dimensions` | 1.1.0 | This document defines a systematic framework for evaluating test completeness. I |
 | `test-driven-development` | 1.2.0 |  |
 | `test-governance` | - |  |
 | `testing-standards` | 3.0.0 | This standard defines actionable testing rules and conventions for AI agents and |
+| `verification-evidence` | 1.0.0 | Establish an "Iron Law" that no task can be claimed as complete without verifica |
 | `versioning` | 1.2.0 | This standard defines how to version software releases using Semantic Versioning |
 | `virtual-organization-standards` | 1.0.0 | This standard treats the AI ecosystem as a "Virtual Organization." It defines ho |
+| `workflow-enforcement` | - |  |
 | `workflow-state-protocol` | 1.0.0 |  |
 
 ---
@@ -298,6 +314,7 @@
 | `check-cli-docs-sync.sh` | CLI-to-Documentation Sync Checker |
 | `check-commands-sync.ps1` | Check Commands Sync |
 | `check-commands-sync.sh` | Commands Sync Checker |
+| `check-commit-spec-reference.sh` | Commit-msg Spec Reference Suggestion — WARNING ONLY (non-blocking) |
 | `check-docs-integrity.ps1` | Check Docs Integrity |
 | `check-docs-integrity.sh` | Documentation Integrity Checker |
 | `check-docs-sync.ps1` | Check Docs Sync |
@@ -320,6 +337,7 @@
 | `check-usage-docs-sync.sh` | check-usage-docs-sync.sh |
 | `check-version-sync.ps1` | Check Version Sync |
 | `check-version-sync.sh` | Version Sync Checker |
+| `check-workflow-compliance.sh` | Workflow Compliance Check — WARNING ONLY (non-blocking) |
 | `convert-md-to-yaml.mjs` | Markdown to AI-YAML Conversion Script |
 | `fix-manifest-paths.ps1` | Fix Manifest Paths |
 | `fix-manifest-paths.sh` | Manifest Path Fixer |

--- a/locales/zh-TW/docs/CHEATSHEET.md
+++ b/locales/zh-TW/docs/CHEATSHEET.md
@@ -1,6 +1,6 @@
 # UDS 速查表
 
-> Quick reference for all UDS features | Last updated: 2026-03-17
+> Quick reference for all UDS features | Last updated: 2026-03-20
 
 **Language**: [English](../../../docs/CHEATSHEET.md) | 繁體中文 | [简体中文](../../zh-CN/docs/CHEATSHEET.md)
 
@@ -24,6 +24,7 @@
 
 | Command | 說明 |
 |---------|-------------|
+| `/ac-coverage` | "[UDS] Generate AC-to-test traceability matrix and coverage report" |
 | `/atdd` | [UDS] Guide through Acceptance Test-Driven Development workflow |
 | `/bdd` | [UDS] Guide through Behavior-Driven Development workflow |
 | `/brainstorm` | "[UDS] Structured AI-assisted brainstorming before spec creation" |
@@ -62,6 +63,7 @@
 
 | Skill | 說明 |
 |-------|-------------|
+| `ac-coverage-assistant` | "[UDS] Analyze AC-to-test traceability and coverage" |
 | `ai-collaboration-standards` | Prevent AI hallucination and ensure evidence-based responses |
 | `ai-friendly-architecture` | Design AI-friendly architecture with explicit patterns, laye |
 | `ai-instruction-standards` | Create and maintain AI instruction files (CLAUDE.md, .cursor |
@@ -116,18 +118,24 @@
 
 | Standard | 說明 |
 |----------|-------------|
+| `acceptance-criteria-traceability` | Acceptance Criteria Traceability Standards |
 | `acceptance-test-driven-development` | Acceptance Test-Driven Development (ATDD) Standards |
 | `accessibility-standards` | This standard defines comprehensive guidelines for |
+| `agent-dispatch` | Define standards for dispatching AI sub-agents in  |
 | `ai-agreement-standards` | This standard formalizes the interaction between H |
 | `ai-friendly-architecture` | This standard defines architecture and documentati |
 | `ai-instruction-standards` | This standard defines best practices for creating  |
 | `anti-hallucination` | This standard defines strict guidelines for AI ass |
+| `api-design-standards` | This standard defines comprehensive guidelines for |
 | `behavior-driven-development` | Behavior-Driven Development (BDD) Standards |
+| `branch-completion` | Define a standardized workflow for completing deve |
+| `change-batching-standards` | Change Batching Standards |
 | `changelog-standards` | This standard defines how to write and maintain a  |
 | `checkin-standards` | This standard defines quality gates that MUST be p |
 | `code-review-checklist` | This standard provides a comprehensive checklist f |
 | `commit-message-guide` | Standardized commit messages improve code review e |
 | `context-aware-loading` | This standard defines a protocol for AI tools to s |
+| `database-standards` | This standard defines guidelines for database desi |
 | `deployment-standards` | This standard defines guidelines for safely deploy |
 | `developer-memory` | This standard defines a structured system for capt |
 | `documentation-structure` | This standard defines a consistent documentation s |
@@ -135,8 +143,11 @@
 | `error-code-standards` | Error Code Standards |
 | `forward-derivation-standards` | This standard defines the principles and workflows |
 | `git-workflow` | This standard defines Git branching strategies and |
+| `git-worktree` | Define a lifecycle for using Git worktrees to isol |
 | `logging-standards` | Logging Standards |
+| `model-selection` | Define a cost-effective strategy for selecting AI  |
 | `performance-standards` | This standard defines comprehensive guidelines for |
+| `pipeline-integration-standards` | Pipeline Integration Standards |
 | `project-context-memory` | This standard defines a structured system for capt |
 | `project-structure` | This standard defines conventions for project dire |
 | `refactoring-standards` | This standard defines comprehensive guidelines for |
@@ -145,12 +156,15 @@
 | `security-standards` | This standard defines comprehensive security guide |
 | `spec-driven-development` | Spec-Driven Development (SDD) Standards |
 | `structured-task-definition` | Structured Task Definition Standards |
+| `systematic-debugging` | Define a structured, four-phase debugging workflow |
 | `test-completeness-dimensions` | This document defines a systematic framework for e |
 | `test-driven-development` | Test-Driven Development (TDD) Standards |
 | `test-governance` | Test Governance Standards |
 | `testing-standards` | This standard defines actionable testing rules and |
+| `verification-evidence` | Establish an "Iron Law" that no task can be claime |
 | `versioning` | This standard defines how to version software rele |
 | `virtual-organization-standards` | This standard treats the AI ecosystem as a "Virtua |
+| `workflow-enforcement` | Workflow Enforcement Standards |
 | `workflow-state-protocol` | Workflow State Protocol |
 
 ## 📜 腳本
@@ -164,6 +178,7 @@
 | `check-cli-docs-sync.sh` | CLI-to-Documentation Sync Checker |
 | `check-commands-sync.ps1` | Check Commands Sync |
 | `check-commands-sync.sh` | Commands Sync Checker |
+| `check-commit-spec-reference.sh` | Commit-msg Spec Reference Suggestion — WARNING ONL |
 | `check-docs-integrity.ps1` | Check Docs Integrity |
 | `check-docs-integrity.sh` | Documentation Integrity Checker |
 | `check-docs-sync.ps1` | Check Docs Sync |
@@ -186,6 +201,7 @@
 | `check-usage-docs-sync.sh` | check-usage-docs-sync.sh |
 | `check-version-sync.ps1` | Check Version Sync |
 | `check-version-sync.sh` | Version Sync Checker |
+| `check-workflow-compliance.sh` | Workflow Compliance Check — WARNING ONLY (non-bloc |
 | `convert-md-to-yaml.mjs` | Markdown to AI-YAML Conversion Script |
 | `fix-manifest-paths.ps1` | Fix Manifest Paths |
 | `fix-manifest-paths.sh` | Manifest Path Fixer |

--- a/locales/zh-TW/docs/FEATURE-REFERENCE.md
+++ b/locales/zh-TW/docs/FEATURE-REFERENCE.md
@@ -1,7 +1,7 @@
 # UDS 功能參考手冊
 
 > Universal Development Standards - 完整功能文件
-> Auto-generated | Last updated: 2026-03-17
+> Auto-generated | Last updated: 2026-03-20
 
 **Language**: [English](../../../docs/FEATURE-REFERENCE.md) | 繁體中文 | [简体中文](../../zh-CN/docs/FEATURE-REFERENCE.md)
 
@@ -10,14 +10,14 @@
 ## 目錄
 
 1. [CLI 指令](#cli-commands) (9)
-2. [斜線命令](#slash-commands) (33)
-3. [技能](#skills) (29)
+2. [斜線命令](#slash-commands) (34)
+3. [技能](#skills) (30)
 4. [代理](#agents) (5)
 5. [工作流程](#workflows) (5)
-6. [核心規範](#core-standards) (36)
-7. [腳本](#scripts) (39)
+6. [核心規範](#core-standards) (48)
+7. [腳本](#scripts) (41)
 
-**Total Features: 156**
+**Total Features: 172**
 
 ---
 
@@ -50,6 +50,8 @@
 | `--locale` | Locale extension (zh-tw) |
 | `--skills-location` | Skills location (marketplace, user, project, none) [default: marketplace] |
 | `--content-mode` | Content mode for integration files (minimal, index, full) [default: index] |
+| `--agents-md` | Generate AGENTS.md universal summary |
+| `--no-agents-md` | Skip AGENTS.md generation |
 | `-y, --yes` | Use defaults, skip interactive prompts |
 | `-E, --experimental` | Enable experimental features (methodology) |
 
@@ -148,6 +150,7 @@
 
 | Command | 說明 |
 |---------|-------------|
+| `/ac-coverage` | "[UDS] Generate AC-to-test traceability matrix and coverage report" |
 | `/atdd` | [UDS] Guide through Acceptance Test-Driven Development workflow |
 | `/bdd` | [UDS] Guide through Behavior-Driven Development workflow |
 | `/brainstorm` | "[UDS] Structured AI-assisted brainstorming before spec creation" |
@@ -188,6 +191,7 @@
 
 | Skill | 說明 |
 |-------|-------------|
+| `ac-coverage-assistant` | "[UDS] Analyze AC-to-test traceability and coverage" |
 | `ai-collaboration-standards` | Prevent AI hallucination and ensure evidence-based responses when analyzing code or making suggestions. |
 | `ai-friendly-architecture` | Design AI-friendly architecture with explicit patterns, layered documentation, and semantic boundaries. |
 | `ai-instruction-standards` | Create and maintain AI instruction files (CLAUDE.md, .cursorrules, etc.) with proper structure. |
@@ -248,27 +252,36 @@
 
 | Standard | 版本 | 說明 |
 |----------|---------|-------------|
+| `acceptance-criteria-traceability` | - |  |
 | `acceptance-test-driven-development` | 1.1.0 |  |
 | `accessibility-standards` | 1.0.0 | This standard defines comprehensive guidelines for creating accessible software  |
+| `agent-dispatch` | 1.0.0 | Define standards for dispatching AI sub-agents in parallel, coordinating their w |
 | `ai-agreement-standards` | 1.0.0 | This standard formalizes the interaction between Human (Acquirer) and AI (Suppli |
 | `ai-friendly-architecture` | 1.0.0 | This standard defines architecture and documentation practices that maximize the |
 | `ai-instruction-standards` | 1.0.0 | This standard defines best practices for creating and maintaining AI instruction |
 | `anti-hallucination` | 1.5.0 | This standard defines strict guidelines for AI assistants to prevent hallucinati |
+| `api-design-standards` | 1.0.0 | This standard defines comprehensive guidelines for designing, building, and main |
 | `behavior-driven-development` | 1.1.0 |  |
+| `branch-completion` | 1.0.0 | Define a standardized workflow for completing development branches, including pr |
+| `change-batching-standards` | - |  |
 | `changelog-standards` | 1.0.2 | This standard defines how to write and maintain a CHANGELOG.md file to communica |
-| `checkin-standards` | 1.4.0 | This standard defines quality gates that MUST be passed before committing code t |
+| `checkin-standards` | 1.5.0 | This standard defines quality gates that MUST be passed before committing code t |
 | `code-review-checklist` | 1.3.0 | This standard provides a comprehensive checklist for reviewing code changes, ens |
 | `commit-message-guide` | 1.3.0 | Standardized commit messages improve code review efficiency, facilitate automate |
 | `context-aware-loading` | 1.0.0 | This standard defines a protocol for AI tools to selectively load development st |
+| `database-standards` | 1.0.0 | This standard defines guidelines for database design, querying, migration, and o |
 | `deployment-standards` | 1.0.0 | This standard defines guidelines for safely deploying software to production, co |
 | `developer-memory` | 1.0.0 | This standard defines a structured system for capturing, retrieving, and surfaci |
 | `documentation-structure` | 1.5.0 | This standard defines a consistent documentation structure for software projects |
 | `documentation-writing-standards` | 1.2.0 | This standard defines documentation requirements based on project types and prov |
-| `error-code-standards` | 1.1.0 |  |
-| `forward-derivation-standards` | 1.1.0 | This standard defines the principles and workflows for Forward Derivation—automa |
+| `error-code-standards` | 1.2.0 |  |
+| `forward-derivation-standards` | 1.2.0 | This standard defines the principles and workflows for Forward Derivation—automa |
 | `git-workflow` | 1.4.0 | This standard defines Git branching strategies and workflows to ensure consisten |
+| `git-worktree` | 1.0.0 | Define a lifecycle for using Git worktrees to isolate development work, ensuring |
 | `logging-standards` | 1.2.0 |  |
+| `model-selection` | 1.0.0 | Define a cost-effective strategy for selecting AI model tiers based on task comp |
 | `performance-standards` | 1.1.0 | This standard defines comprehensive guidelines for software performance engineer |
+| `pipeline-integration-standards` | - |  |
 | `project-context-memory` | 1.1.0 | This standard defines a structured system for capturing, retrieving, and enforci |
 | `project-structure` | 1.2.0 | This standard defines conventions for project directory structure beyond documen |
 | `refactoring-standards` | 2.1.0 | This standard defines comprehensive guidelines for code refactoring, covering ev |
@@ -277,12 +290,15 @@
 | `security-standards` | 1.1.0 | This standard defines comprehensive security guidelines for software development |
 | `spec-driven-development` | 2.1.0 |  |
 | `structured-task-definition` | 1.0.0 |  |
+| `systematic-debugging` | 1.0.0 | Define a structured, four-phase debugging workflow that prevents the common anti |
 | `test-completeness-dimensions` | 1.1.0 | This document defines a systematic framework for evaluating test completeness. I |
 | `test-driven-development` | 1.2.0 |  |
 | `test-governance` | - |  |
 | `testing-standards` | 3.0.0 | This standard defines actionable testing rules and conventions for AI agents and |
+| `verification-evidence` | 1.0.0 | Establish an "Iron Law" that no task can be claimed as complete without verifica |
 | `versioning` | 1.2.0 | This standard defines how to version software releases using Semantic Versioning |
 | `virtual-organization-standards` | 1.0.0 | This standard treats the AI ecosystem as a "Virtual Organization." It defines ho |
+| `workflow-enforcement` | - |  |
 | `workflow-state-protocol` | 1.0.0 |  |
 
 ---
@@ -298,6 +314,7 @@
 | `check-cli-docs-sync.sh` | CLI-to-Documentation Sync Checker |
 | `check-commands-sync.ps1` | Check Commands Sync |
 | `check-commands-sync.sh` | Commands Sync Checker |
+| `check-commit-spec-reference.sh` | Commit-msg Spec Reference Suggestion — WARNING ONLY (non-blocking) |
 | `check-docs-integrity.ps1` | Check Docs Integrity |
 | `check-docs-integrity.sh` | Documentation Integrity Checker |
 | `check-docs-sync.ps1` | Check Docs Sync |
@@ -320,6 +337,7 @@
 | `check-usage-docs-sync.sh` | check-usage-docs-sync.sh |
 | `check-version-sync.ps1` | Check Version Sync |
 | `check-version-sync.sh` | Version Sync Checker |
+| `check-workflow-compliance.sh` | Workflow Compliance Check — WARNING ONLY (non-blocking) |
 | `convert-md-to-yaml.mjs` | Markdown to AI-YAML Conversion Script |
 | `fix-manifest-paths.ps1` | Fix Manifest Paths |
 | `fix-manifest-paths.sh` | Manifest Path Fixer |


### PR DESCRIPTION
## Summary

- `uds check` 新增 `checkAgentsMdSync()`：驗證 AGENTS.md 中列出的標準與 manifest 是否同步，檢查 150 行限制
- 重新生成 usage docs 以反映 `--agents-md` flag（修復 pre-release check 的 usage-docs-sync 失敗）

## Test Plan

- [x] 1580 unit tests passed
- [x] `check-usage-docs-sync.sh` passed
- [x] Lint: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)