### PR TITLE
chore(deps): 升級 commander 至 v14

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
-        "commander": "^12.1.0",
+        "commander": "^14.0.0",
         "inquirer": "^9.2.12",
         "js-yaml": "^4.1.0",
         "ora": "^9.3.0"
@@ -1252,6 +1252,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1626,12 +1627,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -1794,6 +1795,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2761,16 +2763,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/listr2": {
@@ -3999,6 +3991,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4092,6 +4085,7 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/cli/package.json
+++ b/cli/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
-    "commander": "^12.1.0",
+    "commander": "^14.0.0",
     "inquirer": "^9.2.12",
     "js-yaml": "^4.1.0",
     "ora": "^9.3.0"


### PR DESCRIPTION
## Summary
- 將 commander 從 v12.1.0 升級至 v14.0.0
- Node.js 已要求 >=20.0.0，符合 commander 14 的版本需求
- `configureOutput({ outputVersion })` 用法相容，無需修改程式碼

## 測試結果
- 1682 個快速測試通過
- 1812 個完整測試（含 E2E）通過
- Linter 0 errors
- `--version` 和 `--help` 手動驗證通過

## Test plan
- [x] `npm run test:quick` — 快速驗證
- [x] `npm test` — 完整測試含 E2E
- [x] `npm run lint` — 程式碼風格
- [x] `uds --version` — configureOutput 驗證
- [x] `uds --help` — help 輸出驗證

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)