### PR TITLE
feat(standards): add DEC-043 Wave 1 reliability + governance meta standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npx universal-dev-standards init
 <!-- UDS_STATS_TABLE_START -->
 | Category | Count | Description |
 |----------|-------|-------------|
-| **Core Standards** | 72 | Universal development guidelines |
+| **Core Standards** | 78 | Universal development guidelines |
 | **AI Skills** | 48 | Interactive skills |
 | **Slash Commands** | 48 | Quick actions |
 | **CLI Commands** | 6 | list, init, configure, check, update, skills |

--- a/ai/standards/health-check-standards.ai.yaml
+++ b/ai/standards/health-check-standards.ai.yaml
@@ -1,0 +1,140 @@
+# Health Check Standards - AI Optimized
+# Source: XSPEC-067 (DEC-043 Wave 1 Reliability Pack)
+
+standard:
+  id: health-check-standards
+  name: Health Check Standards
+  description: 健康檢查標準 — liveness / readiness / startup 三種 probe、深度 health check、結構化 JSON 回應
+
+  meta:
+    version: "1.0.0"
+    updated: "2026-04-17"
+    status: trial
+    since: "2026-04-17"
+    expires: "2026-10-17"
+    source: XSPEC-067
+    borrowed_from: DEC-043
+    description: >
+      業界常見錯誤：把 liveness 和 readiness 混用（健康檢查檢查外部依賴導致連鎖重啟）。
+      本標準明確三種 probe 語意分離、定義深度 health check 的檢查範圍（僅關鍵依賴）、
+      並規範結構化 JSON 回應以便下游自動化處理。與 observability 整合為 RED metric 的 Error 來源之一。
+    scope: universal
+    industry_reference: "Kubernetes probes, Microsoft eShop health checks, Google SRE Book Ch.6"
+
+  guidelines:
+    - "Liveness probe 不得檢查外部依賴（DB、下游 API），否則會造成連鎖重啟"
+    - "Readiness probe 可檢查關鍵外部依賴，但僅關鍵（非全部依賴）"
+    - "慢啟動服務應使用 startup probe，啟動完成後交棒給 liveness"
+    - "Health check 端點必須回傳結構化 JSON，包含 status / dependencies / timestamp"
+    - "Health check 結果應作為 observability 的 Error signal 之一，連續 fail 觸發 incident"
+
+  probe_types:
+    liveness:
+      purpose: "服務是否還活著（process 是否卡死）"
+      endpoint_suggestion: "GET /health/live"
+      checks:
+        allowed:
+          - "process 是否能回應 HTTP"
+          - "內部 event loop 是否可用"
+        forbidden:
+          - "DB 連線（DB 壞時 liveness 失敗 → pod 重啟 → 啟動更多 client → DB 更壞）"
+          - "下游 API（會造成連鎖重啟）"
+          - "消息佇列"
+      on_fail: "重啟 pod / process"
+      failure_threshold: 3
+      period_seconds: 10
+
+    readiness:
+      purpose: "是否可接收流量"
+      endpoint_suggestion: "GET /health/ready"
+      checks:
+        allowed:
+          - "自身 API 可用"
+          - "DB 連線可用（若服務必須依賴 DB 才能工作）"
+          - "關鍵下游依賴可用（非全部下游）"
+          - "必要的設定 / 憑證已載入"
+        forbidden:
+          - "非關鍵依賴（避免非關鍵故障造成服務被移出負載均衡）"
+      on_fail: "移出負載均衡，不重啟"
+      failure_threshold: 3
+      period_seconds: 5
+
+    startup:
+      purpose: "啟動期專用，替代慢啟動服務的 liveness"
+      endpoint_suggestion: "GET /health/startup"
+      checks:
+        - "啟動過程所需資源（如快取預熱、index 載入）已完成"
+      on_fail: "重啟 pod（啟動超時）"
+      handover: "通過後停用，改由 liveness 接手"
+      failure_threshold: 30
+      period_seconds: 10
+
+  depth_rules:
+    shallow:
+      when: "liveness"
+      checks: "process 是否可回應，不碰任何外部依賴"
+    deep:
+      when: "readiness"
+      checks:
+        - "自身 API 路由可解析"
+        - "DB ping 成功（若必須 DB）"
+        - "關鍵下游 API ping 成功（非全部）"
+      note: "關鍵依賴的定義：沒有它服務就完全無法提供核心功能"
+
+  response_format:
+    content_type: "application/json"
+    status_codes:
+      "200": "healthy — 所有關鍵依賴正常"
+      "503": "unhealthy — 至少一個關鍵依賴失敗"
+    schema:
+      status: "healthy | degraded | unhealthy"
+      timestamp: "ISO-8601"
+      uptime_seconds: number
+      dependencies:
+        description: "每個被檢查的依賴的狀態（僅 readiness / deep check 回傳）"
+        example:
+          database:
+            status: "healthy | unhealthy"
+            latency_ms: number
+            last_check: "ISO-8601"
+          upstream_api:
+            status: "healthy | unhealthy"
+            latency_ms: number
+      version: "service version string"
+
+  observability_integration:
+    rule_1: "Health check 結果應作為 RED metric 的 Error 來源之一（Rate / Errors / Duration）"
+    rule_2: "連續 N 次 health check failed 應觸發 incident（對齊 incident-response）"
+    rule_3: "probe 延遲本身應被監控（異常緩慢可能是 resource_exhaustion 徵兆）"
+
+  scenarios:
+    scenario_1_liveness_not_checking_db:
+      given: "DB 暫時無法連線（連線池耗盡）"
+      when: "liveness probe 被呼叫"
+      then: "回傳 200 healthy（liveness 不檢查 DB）"
+      note: "避免 DB 連鎖故障導致所有 pod 重啟"
+
+    scenario_2_readiness_fails_on_critical_dep:
+      given: "關鍵下游 API 不可達（服務無法處理任何請求）"
+      when: "readiness probe 被呼叫"
+      then: "回傳 503 unhealthy，dependencies.upstream_api.status=unhealthy"
+      and: "pod 被移出負載均衡，但 process 不重啟"
+      note: "readiness fail → 不接流量；liveness 仍 healthy → 不重啟"
+
+    scenario_3_startup_then_liveness_handover:
+      given: "服務需 60s 預熱快取"
+      when: "pod 啟動"
+      then: "startup probe 檢查預熱狀態，前 60s 持續回 503"
+      and: "預熱完成後 startup 回 200，自此停用，改由 liveness 接手"
+      note: "避免慢啟動服務在預熱中被誤判為 crash 重啟"
+
+  error_codes:
+    HC-001: "HEALTH_CHECK_FAILED — 關鍵依賴失敗"
+    HC-002: "HEALTH_CHECK_TIMEOUT — probe 本身超時"
+    HC-003: "INVALID_DEPENDENCY_SET — readiness 檢查了非關鍵依賴（設計違規）"
+
+  integration_points:
+    - "observability-standards（XSPEC-063 規劃中）— health check 是 RED metric 的 Error 來源"
+    - "incident-response-assistant — 連續 health check failed 觸發 incident 流程"
+    - "circuit-breaker.ai.yaml — breaker OPEN 時 readiness 應回 degraded"
+    - "deployment-standards.ai.yaml — K8s probe 配置對應三種 probe 類型"

--- a/ai/standards/retry-standards.ai.yaml
+++ b/ai/standards/retry-standards.ai.yaml
@@ -1,0 +1,134 @@
+# Retry Standards - AI Optimized
+# Source: XSPEC-067 (DEC-043 Wave 1 Reliability Pack)
+
+standard:
+  id: retry-standards
+  name: Retry Standards
+  description: 重試策略標準 — 指數退避加抖動、重試上限、依 failure-source 分類的重試規則
+
+  meta:
+    version: "1.0.0"
+    updated: "2026-04-17"
+    status: trial
+    since: "2026-04-17"
+    expires: "2026-10-17"
+    source: XSPEC-067
+    borrowed_from: DEC-043
+    description: >
+      延伸既有 circuit-breaker 與 failure-source-taxonomy，補齊 retry 層的標準化規則。
+      避免各元件各自實作重試造成行為不一致（無上限重試、無 jitter 導致 thundering herd）。
+      與 failure-source-taxonomy 深度整合：依失敗類型決定是否重試、重試幾次、退避多久。
+    scope: universal
+    industry_reference: "Netflix Hystrix retry, Google SRE Book Ch.22, AWS Architecture Blog - exponential backoff and jitter"
+
+  guidelines:
+    - "所有重試邏輯必須使用 exponential + jitter，禁止固定間隔或無 jitter 的純指數"
+    - "重試必須有明確上限（max_attempts），禁止無限重試"
+    - "重試決策必須先參考 failure-source-taxonomy 分類，fail-fast 類別不得重試"
+    - "重試必須與 circuit-breaker 整合：OPEN 狀態下不得重試，直接 fail-fast"
+    - "每次重試都應透過遙測事件上報（retry_attempted / retry_exhausted），方便觀察無效重試"
+
+  backoff_formula:
+    name: "Exponential with full jitter"
+    formula: "wait_ms = min(cap_ms, base_ms * 2^attempt) * (0.5 + random() * 0.5)"
+    defaults:
+      base_ms: 100
+      cap_ms: 30000
+      max_attempts: 5
+      jitter_ratio: 0.5
+    rationale:
+      - "Exponential 隨重試次數指數退避，避免短時間大量請求"
+      - "Jitter ±50% 避免 thundering herd（所有 client 同時重試）"
+      - "cap_ms=30s 避免超長等待，與典型 request timeout 對齊"
+
+  failure_source_rules:
+    description: "依 failure-source-taxonomy 的 8 類 failureSource 決定重試策略"
+    rules:
+      transient_network:
+        retry: true
+        max_attempts: 5
+        base_ms: 100
+        note: "短暫網路抖動，指數退避通常可恢復"
+      rate_limit:
+        retry: true
+        max_attempts: 3
+        base_ms: 1000
+        note: "底數加大（1s）預留額度恢復時間；若 API 回傳 Retry-After 則優先採用"
+      upstream_unavailable:
+        retry: true
+        max_attempts: 3
+        base_ms: 500
+        note: "重試前先查 circuit-breaker；連續失敗觸發 OPEN 狀態"
+      tool_failure:
+        retry: true
+        max_attempts: 2
+        base_ms: 200
+        note: "工具層失敗通常非 transient，僅給 2 次機會"
+      prompt_delivery:
+        retry: true
+        max_attempts: 2
+        base_ms: 100
+        note: "多半是短暫 API 問題；超過 2 次改走 model_switch"
+      authentication:
+        retry: false
+        note: "fail-fast；憑證錯誤重試不會變對，只會浪費 quota"
+      validation:
+        retry: false
+        note: "fail-fast；input 錯誤重試結果不變"
+      policy_violation:
+        retry: false
+        note: "fail-fast；安全決策禁止繞過（對齊 security-decision 標準）"
+      quota_exhausted:
+        retry: false
+        note: "fail-fast；等 budget reset 或升級 tier，不應在同 session 內重試"
+
+  circuit_breaker_integration:
+    rule_1: "每次重試前檢查對應 breaker 的 state；若為 OPEN 立即回傳 CircuitOpenError，不消耗 max_attempts"
+    rule_2: "重試全部耗盡（retry_exhausted）計入 breaker 的 failure count"
+    rule_3: "HALF_OPEN 狀態下僅允許 1 次探針重試，不套用 max_attempts"
+
+  telemetry_events:
+    retry_attempted:
+      fields:
+        operation: string
+        attempt: number
+        max_attempts: number
+        failure_source: "FailureSource | null"
+        wait_ms: number
+      when: "每次重試前上傳（第 0 次原始呼叫不算）"
+    retry_exhausted:
+      fields:
+        operation: string
+        attempts: number
+        final_failure_source: FailureSource
+      when: "達到 max_attempts 仍失敗時上傳"
+
+  scenarios:
+    scenario_1_exponential_backoff:
+      given: "呼叫下游 API 失敗，failure_source=transient_network，已重試 2 次"
+      when: "計算第 3 次重試的等待時間"
+      then: "wait_ms = min(30000, 100 * 2^3) * (0.5 + random * 0.5) = 800 * [0.5..1.0] = 400~800ms"
+      note: "驗證退避公式正確套用 jitter"
+
+    scenario_2_fail_fast_on_auth:
+      given: "API 回傳 401 Unauthorized，偵測元件標記 failure_source=authentication"
+      when: "決定是否重試"
+      then: "立即 fail-fast，不進入退避，不計入 circuit-breaker failure count"
+      note: "authentication 類別 retry=false，避免浪費 quota"
+
+    scenario_3_circuit_open_skip:
+      given: "對應 breaker 為 OPEN 狀態，cooldown 剩 15s"
+      when: "發起重試"
+      then: "立即回傳 CircuitOpenError，不發起請求，不消耗 max_attempts"
+      note: "與 circuit-breaker 整合：OPEN 狀態下 fail-fast"
+
+  error_codes:
+    RETRY-001: "RETRY_EXHAUSTED — 達到 max_attempts 仍失敗"
+    RETRY-002: "RETRY_SKIPPED_NON_RETRYABLE — failure_source 屬 fail-fast 類別"
+    RETRY-003: "RETRY_SKIPPED_CIRCUIT_OPEN — breaker OPEN 狀態下跳過重試"
+
+  integration_points:
+    - "circuit-breaker.ai.yaml — OPEN 狀態下禁止重試，retry_exhausted 計入 failure count"
+    - "failure-source-taxonomy.ai.yaml — 依 failureSource 決定 retry/fail-fast"
+    - "timeout-standards.ai.yaml — 單次重試 timeout 不得超過剩餘 deadline"
+    - "recovery-recipe-registry.ai.yaml — retry 耗盡後交棒給 recovery recipe"

--- a/ai/standards/skill-standard-alignment-check.ai.yaml
+++ b/ai/standards/skill-standard-alignment-check.ai.yaml
@@ -1,0 +1,119 @@
+# Skill-Standard Alignment Check - AI Optimized
+# Source: XSPEC-070 (DEC-043 Wave 1 Governance Meta Pack)
+
+standard:
+  id: skill-standard-alignment-check
+  name: Skill-Standard Alignment Check
+  description: Skill 必有 Standard 作為錨點，Standard 可無 Skill；定期識別孤兒 Skill
+
+  meta:
+    version: "1.0.0"
+    updated: "2026-04-17"
+    status: trial
+    since: "2026-04-17"
+    expires: "2026-10-17"
+    source: XSPEC-070
+    borrowed_from: DEC-043
+    description: >
+      Skill 是 UX 糖衣，Standard 是 standards-of-truth。若 Skill 無錨定 Standard，
+      其行為就沒有明文依據，會隨作者口味飄移。本標準規範 Skill 必須指明錨定哪個 Standard，
+      並定期識別「孤兒 Skill」（無對應 Standard），觸發補 Standard 的流程。
+      反向允許 Standard 無 Skill（不強制每個 Standard 都造 Skill）。
+    scope: universal
+    industry_reference: "AsiaOstrich DEC-043 七主題缺口分析（slo/runbook/observability 等 40+ Skill 部分無 Standard 錨點）"
+
+  guidelines:
+    - "所有 Skill 必須在 frontmatter 指明 anchor_standard（至少一個）"
+    - "anchor_standard 必須指向 Trial / Active / Deprecated 狀態的標準 id"
+    - "Skill 無 anchor_standard 視為 orphan，必須在下一版補上或降級為 Proposed"
+    - "Standard 無對應 Skill 是合法的（Standard 可獨立存在，Skill 僅為 UX 加速）"
+    - "定期（建議季度）執行 alignment check，產出 orphan Skill 清單"
+
+  alignment_rules:
+    skill_must_have_standard:
+      rule: "Skill 的 frontmatter 必須包含 anchor_standard 欄位"
+      format: "anchor_standard: <standard-id> 或 [<standard-id-1>, <standard-id-2>, ...]"
+      enforcement: "CI / pre-release check 強制，缺欄位視為 fail"
+      exception: "純 utility Skill（如 docs-generator）可標記 anchor_standard: none + 填 utility_reason"
+
+    standard_may_have_skill:
+      rule: "Standard 是否有對應 Skill 不強制"
+      rationale:
+        - "Standard 是 standards-of-truth，可被 QualityGate / Agent 直接消費"
+        - "Skill 僅是 UX 糖衣，不是 Standard 的必要條件"
+        - "強制每 Standard 都造 Skill 會導致 Skill 庫膨脹"
+      example: "immutability-first 標準無對應 Skill — 合法"
+
+    orphan_skill_detection:
+      rule: "沒有 anchor_standard 的 Skill 視為 orphan"
+      action_on_detected:
+        - "列入季度報告"
+        - "建立對應 Standard 的 XSPEC（循 admission-criteria 流程）"
+        - "若無法建立 Standard，降 Skill 為 Proposed 直到有錨點"
+
+  known_orphans_2026_04:
+    description: "本 XSPEC-070 識別的現存 orphan Skill（由 XSPEC-063~069 補齊）"
+    list:
+      - skill_id: "slo-assistant"
+        needs_standard: "slo-standards (XSPEC-063 規劃中)"
+      - skill_id: "runbook-assistant"
+        needs_standard: "runbook-standards (XSPEC-064 規劃中)"
+      - skill_id: "incident-response-assistant"
+        needs_standard: "incident-response-standards (XSPEC-063 規劃中)"
+      - skill_id: "observability-assistant"
+        needs_standard: "observability-standards (XSPEC-063 規劃中)"
+      - skill_id: "metrics-dashboard-assistant"
+        needs_standard: "metrics-dashboard-standards (XSPEC-063 規劃中)"
+      - skill_id: "ci-cd-assistant"
+        needs_standard: "ci-cd-standards (XSPEC-066 規劃中)"
+    note: "清單將隨 XSPEC-063~069 實作逐步清空"
+
+  alignment_check_workflow:
+    step_1: "掃描 skills/**/*.md 抽取 frontmatter anchor_standard"
+    step_2: "掃描 ai/standards/*.ai.yaml 抽取所有 standard.id"
+    step_3: "計算差集：Skill without anchor_standard → orphan 清單"
+    step_4: "計算反向差集：Standard without Skill → informational（非錯誤）"
+    step_5: "若 anchor_standard 指向不存在的 id 或已 Archived 的 id → 錯誤"
+    output: "alignment-report.json / alignment-report.md（含 orphan 清單、broken anchor 清單）"
+
+  scenarios:
+    scenario_1_skill_with_valid_anchor:
+      given: "retry-assistant Skill frontmatter 含 anchor_standard: retry-standards"
+      when: "執行 alignment check"
+      then: "retry-standards 存在且狀態為 Trial，檢查通過"
+      note: "典型的健康 Skill-Standard 對齊"
+
+    scenario_2_orphan_skill_detected:
+      given: "slo-assistant Skill 無 anchor_standard 欄位"
+      when: "執行 alignment check"
+      then: "列入 orphan 清單，狀態報告標註「需建立 slo-standards 或降級為 Proposed」"
+      note: "對齊 XSPEC-063 計畫補 slo-standards 的需求"
+
+    scenario_3_standard_without_skill_ok:
+      given: "immutability-first.ai.yaml 存在，但無對應 immutability-assistant Skill"
+      when: "執行 alignment check"
+      then: "standalone-standard 計數 +1，不視為錯誤"
+      note: "Standard 可獨立存在；強制每 Standard 造 Skill 不合理"
+
+  telemetry_events:
+    alignment_check_run:
+      fields:
+        total_skills: number
+        total_standards: number
+        orphan_skills_count: number
+        broken_anchors_count: number
+        standalone_standards_count: number
+        timestamp: string
+      when: "每次 alignment check 執行時上報"
+
+  error_codes:
+    ALIGN-001: "SKILL_MISSING_ANCHOR — Skill frontmatter 缺 anchor_standard"
+    ALIGN-002: "BROKEN_ANCHOR — anchor_standard 指向不存在的 standard id"
+    ALIGN-003: "ARCHIVED_ANCHOR — anchor_standard 指向已 Archived 的標準"
+    ALIGN-004: "UTILITY_MISSING_REASON — utility Skill 標 anchor_standard=none 但缺 utility_reason"
+
+  integration_points:
+    - "standard-admission-criteria.ai.yaml — orphan Skill 促成新 Standard 申請"
+    - "standard-lifecycle-management.ai.yaml — anchor 必須指向非 Archived 狀態標準"
+    - "pre-release-check.sh — alignment check 可整合為 release gate（選用）"
+    - "DEC-043 — XSPEC-063~069 的主要目的之一即是清空本標準識別的 orphan 清單"

--- a/ai/standards/standard-admission-criteria.ai.yaml
+++ b/ai/standards/standard-admission-criteria.ai.yaml
@@ -1,0 +1,107 @@
+# Standard Admission Criteria - AI Optimized
+# Source: XSPEC-070 (DEC-043 Wave 1 Governance Meta Pack)
+
+standard:
+  id: standard-admission-criteria
+  name: Standard Admission Criteria
+  description: 新標準納入 UDS 的四項條件（Evidence / Scope / Non-overlapping / AI-executable）與拒絕理由明文化
+
+  meta:
+    version: "1.0.0"
+    updated: "2026-04-17"
+    status: trial
+    since: "2026-04-17"
+    expires: "2026-10-17"
+    source: XSPEC-070
+    borrowed_from: DEC-043
+    description: >
+      在 DEC-043 提出 60+ 候選新標準的背景下，需要一個明文的納入檢查清單，
+      避免標準庫膨脹（重疊、未使用）與降低品質。本標準是 UDS 的治理層 meta 標準，
+      用來「決定標準的標準」。每個候選新標準必須通過四項條件才能從 Proposed 進入 Trial。
+    scope: universal
+    industry_reference: "IETF RFC admission criteria, Python PEP process, W3C Recommendation Track"
+
+  guidelines:
+    - "所有候選新標準必須填寫 admission checklist，缺任一項視為不合格"
+    - "拒絕候選標準時必須寫下明文理由，不得以「不合適」之類籠統用詞草率結案"
+    - "通過 admission 僅代表可進 Trial，不代表直接 Active（需通過試驗期驗證）"
+    - "本標準本身也必須符合四項條件（self-applicability 原則）"
+    - "既有 66 個 Active 標準不溯及既往；新增標準自本標準發布後適用"
+
+  criteria:
+    evidence:
+      description: "至少 2 個具體使用場景（非 hypothetical）"
+      checks:
+        - "場景來自實際專案、Repo、論文或 DEC 記錄"
+        - "場景描述具體（可舉出檔案 / 函式 / commit），非泛泛而談"
+        - "至少 1 個場景來自 AsiaOstrich 三專案內部痛點或外部產業佐證"
+      rejection_example: "「未來可能用到」— 無具體場景，不通過"
+
+    scope:
+      description: "明確的作用域（哪些活動 / 哪些子專案 / 哪些情境）"
+      checks:
+        - "在 meta.scope 標示 universal / partial / uds-specific"
+        - "frontmatter 列出適用的活動類型（如 development, deployment, testing）"
+        - "若為 partial 或 uds-specific，說明不通用的原因"
+      rejection_example: "「所有場合都適用」— 過度泛化，不通過"
+
+    non_overlapping:
+      description: "與既有 UDS 標準無重大重疊（< 30% 內容重複）"
+      checks:
+        - "列出最接近的 3 個既有標準，說明如何補足差異"
+        - "若有 ≥ 30% 重疊，應改為擴充既有標準而非新增"
+        - "定義 integration_points 說明與既有標準的關係"
+      rejection_example: "與既有 `retry-standards` 80% 內容重複 — 應合併，不通過"
+
+    ai_executable:
+      description: "至少一個 DevAP QualityGate / VibeOps Agent prompt / Skill 能消費此標準"
+      checks:
+        - "定義清楚的 guidelines（bullet point，每條可驗證）"
+        - "至少包含 2 個具體 scenarios（Given-When-Then 格式）"
+        - "若需型別 / 介面，提供 interface / types 區塊"
+        - "與現有 Skill / QualityGate 的 integration_points 明確"
+      rejection_example: "只有抽象原則，無任何 AI 可執行的規則 — 不通過"
+
+  rejection_protocol:
+    rule_1: "拒絕理由必須具體指出未通過的 criterion（evidence / scope / non-overlapping / ai-executable）"
+    rule_2: "拒絕記錄寫入 `cross-project/decisions/` 或 DEC 的 rejection log 區塊"
+    rule_3: "候選者可依理由修正後重新申請（不永久封鎖）"
+    rule_4: "若拒絕理由涉及與既有標準重疊，應建議改為擴充既有標準"
+
+  self_applicability:
+    description: "本標準也必須符合四項條件"
+    evidence: "DEC-043 的 60+ 候選標準 + XSPEC-070 scenario 1-3 為具體使用場景"
+    scope: "universal，作用於 UDS 自身治理"
+    non_overlapping: "與既有 adr-standards 互補（ADR 記錄決策，admission 記錄納入條件）"
+    ai_executable: "本 yaml 的 scenarios 可被 standard-lifecycle Skill 消費"
+
+  scenarios:
+    scenario_1_new_standard_passes:
+      given: "候選標準 `retry-standards` 申請納入"
+      when: "執行 admission 檢查"
+      then: "Evidence（XSPEC-067 Scenario 1-1/1-2）、Scope（universal）、Non-overlapping（與 circuit-breaker 互補）、AI-executable（9 條 guidelines + 3 scenarios）全部通過"
+      and: "狀態從 Proposed 進入 Trial"
+
+    scenario_2_rejected_for_overlap:
+      given: "候選標準 `advanced-retry-with-jitter` 申請納入"
+      when: "Non-overlapping 檢查"
+      then: "與既有 retry-standards 重疊 > 30%，拒絕"
+      and: "拒絕理由：「80% 內容與 retry-standards 重疊，建議改為擴充既有標準的 Phase 2」"
+
+    scenario_3_rejected_for_vague_evidence:
+      given: "候選標準 `universal-best-practices` 申請納入"
+      when: "Evidence 檢查"
+      then: "無具體場景，只有「未來可能用到」類描述，拒絕"
+      and: "拒絕理由：「缺具體場景，請提供至少 2 個已發生的使用案例或產業佐證」"
+
+  error_codes:
+    ADMISSION-001: "MISSING_EVIDENCE — Evidence criterion 未通過"
+    ADMISSION-002: "SCOPE_UNDEFINED — Scope criterion 未通過"
+    ADMISSION-003: "OVERLAP_EXCEEDED — 與既有標準重疊 > 30%"
+    ADMISSION-004: "NOT_AI_EXECUTABLE — 缺 guidelines / scenarios，AI 無法消費"
+
+  integration_points:
+    - "standard-lifecycle-management.ai.yaml — 通過 admission 後從 Proposed → Trial"
+    - "skill-standard-alignment-check.ai.yaml — admission 通過的標準才能被 Skill 錨定"
+    - "adr-standards.ai.yaml — admission 決策本身可能需要 ADR 記錄"
+    - "DEC-043 — 本標準是 Wave 1 的前置條件，後續 Wave 2/3 的候選都走此流程"

--- a/ai/standards/standard-lifecycle-management.ai.yaml
+++ b/ai/standards/standard-lifecycle-management.ai.yaml
@@ -1,0 +1,144 @@
+# Standard Lifecycle Management - AI Optimized
+# Source: XSPEC-070 (DEC-043 Wave 1 Governance Meta Pack)
+
+standard:
+  id: standard-lifecycle-management
+  name: Standard Lifecycle Management
+  description: UDS 標準生命週期狀態機（Proposed → Trial → Active → Deprecated → Archived）與 frontmatter 必要欄位
+
+  meta:
+    version: "1.0.0"
+    updated: "2026-04-17"
+    status: trial
+    since: "2026-04-17"
+    expires: "2026-10-17"
+    source: XSPEC-070
+    borrowed_from: DEC-043
+    description: >
+      既有 66 個標準無明確狀態管理：新增標準沒有試驗期、過時標準無棄用路徑、廢棄標準仍被引用。
+      本標準建立五狀態機（Proposed / Trial / Active / Deprecated / Archived）與合法轉移規則，
+      並規範所有 .ai.yaml 標準必須在 frontmatter 標示 status / since / expires / supersedes。
+    scope: universal
+    industry_reference: "IETF RFC lifecycle (Proposed → Draft → Internet Standard), Python PEP states, W3C Recommendation Track"
+
+  guidelines:
+    - "所有 .ai.yaml 標準 frontmatter 必須包含 status / since 欄位"
+    - "Trial 狀態必須指定 expires（試驗期限，預設 6 個月）"
+    - "Deprecated 狀態必須指定 supersedes（替代者的 standard id 或遷移文件路徑）"
+    - "禁止反向轉移（Active → Proposed、Archived → Active 無意義）"
+    - "Trial → Active 需在 expires 前完成驗證決定；逾期未決則自動 Archived"
+
+  states:
+    Proposed:
+      description: "草案階段，尚未通過 admission-criteria"
+      allowed_locations: "DEC 文件 / XSPEC 文件 / PR branch；不進主線 ai/standards/"
+      can_be_referenced_by_skill: false
+      transition_out: ["Trial"]
+      transition_criteria:
+        Trial: "通過 standard-admission-criteria 四項條件"
+
+    Trial:
+      description: "批准但試驗中，有明確試驗期限"
+      allowed_locations: "ai/standards/，frontmatter 標記 status=trial"
+      can_be_referenced_by_skill: "true (標註 trial 狀態)"
+      default_trial_period_months: 6
+      transition_out: ["Active", "Archived"]
+      transition_criteria:
+        Active: "試驗期內被至少 2 個獨立場景實際使用且無重大修正需求"
+        Archived: "試驗期結束未達 Active 條件，或發現根本設計缺陷"
+
+    Active:
+      description: "全面採用，是 standard-of-truth"
+      allowed_locations: "ai/standards/，frontmatter 標記 status=active"
+      can_be_referenced_by_skill: true
+      transition_out: ["Deprecated"]
+      transition_criteria:
+        Deprecated: "發現更好替代標準、或標準已過時、或業界實踐改變"
+
+    Deprecated:
+      description: "標記棄用，仍可用但不建議；必須提供遷移路徑"
+      allowed_locations: "ai/standards/，frontmatter 標記 status=deprecated + supersedes"
+      can_be_referenced_by_skill: "true (Skill 應警示 deprecated 並指向 supersedes)"
+      default_migration_period_months: 6
+      transition_out: ["Archived"]
+      transition_criteria:
+        Archived: "遷移期結束，所有 downstream 已切換至替代標準"
+
+    Archived:
+      description: "已移除，僅保留歷史紀錄；不再載入"
+      allowed_locations: "ai/standards/archive/ 或 git 歷史"
+      can_be_referenced_by_skill: false
+      transition_out: []
+
+  transition_matrix:
+    description: "合法狀態轉移路徑（其他皆禁止）"
+    legal_transitions:
+      - "Proposed → Trial"
+      - "Trial → Active"
+      - "Trial → Archived"
+      - "Active → Deprecated"
+      - "Deprecated → Archived"
+    forbidden_transitions:
+      - "Active → Proposed（無意義）"
+      - "Archived → Active（應重新申請 admission）"
+      - "Deprecated → Active（應重新 Trial）"
+      - "Proposed → Active（須先 Trial 驗證）"
+
+  frontmatter_required_fields:
+    description: "所有 .ai.yaml 標準必須在 meta 區塊包含的欄位"
+    always_required:
+      status: "proposed | trial | active | deprecated | archived"
+      since: "ISO-8601 日期，進入當前狀態的日期"
+      version: "semver 字串"
+    conditional_required:
+      expires:
+        when: "status = trial"
+        format: "ISO-8601 日期，預設 since + 6 months"
+      supersedes:
+        when: "status = deprecated"
+        format: "替代標準 id（如 'retry-standards-v2'）或遷移文件路徑"
+      migration_guide:
+        when: "status = deprecated"
+        format: "遷移指引的相對路徑（選填，但強烈建議）"
+
+  scenarios:
+    scenario_1_trial_to_active:
+      given: "retry-standards 處於 trial 狀態，since=2026-04-17, expires=2026-10-17"
+      when: "2026-08-01 審視使用情況，發現 DevAP Fix Loop 和 VibeOps Builder 都已採用，無重大缺陷"
+      then: "轉移到 Active，更新 status=active, since=2026-08-01，移除 expires 欄位"
+      note: "Trial → Active 的典型路徑"
+
+    scenario_2_trial_auto_archive:
+      given: "某標準 trial 期限 2026-10-17 到期，尚未通過驗證"
+      when: "2026-10-17 自動審視"
+      then: "狀態轉為 Archived，記錄未通過原因"
+      note: "避免 Trial 標準無限期停留，造成標準庫混亂"
+
+    scenario_3_deprecated_with_migration:
+      given: "legacy-retry-logic 發現有更好的 retry-standards 取代"
+      when: "執行 deprecation"
+      then: "status=deprecated, since=2026-04-17, supersedes=retry-standards, migration_guide=docs/migrations/retry-v1-to-v2.md"
+      and: "Skill 使用 legacy-retry-logic 時顯示警告，建議遷移至 retry-standards"
+
+  telemetry_events:
+    standard_state_change:
+      fields:
+        standard_id: string
+        from_state: "proposed | trial | active | deprecated | archived"
+        to_state: "proposed | trial | active | deprecated | archived"
+        reason: string
+        timestamp: string
+      when: "每次標準狀態變更時上報（對齊 telemetry-server）"
+
+  error_codes:
+    LIFECYCLE-001: "MISSING_STATUS — frontmatter 缺 status 欄位"
+    LIFECYCLE-002: "MISSING_EXPIRES — trial 狀態缺 expires 欄位"
+    LIFECYCLE-003: "MISSING_SUPERSEDES — deprecated 狀態缺 supersedes 欄位"
+    LIFECYCLE-004: "FORBIDDEN_TRANSITION — 嘗試非法狀態轉移"
+    LIFECYCLE-005: "TRIAL_EXPIRED — Trial 期限已過但未完成 Active / Archived 決策"
+
+  integration_points:
+    - "standard-admission-criteria.ai.yaml — Proposed → Trial 必須通過 admission"
+    - "skill-standard-alignment-check.ai.yaml — Skill 僅可錨定 trial/active/deprecated 狀態標準"
+    - "adr-standards.ai.yaml — Active → Deprecated 的決策建議搭配 ADR 記錄"
+    - "telemetry-server — standard_state_change 事件匯總，用於分析標準演進"

--- a/ai/standards/timeout-standards.ai.yaml
+++ b/ai/standards/timeout-standards.ai.yaml
@@ -1,0 +1,104 @@
+# Timeout Standards - AI Optimized
+# Source: XSPEC-067 (DEC-043 Wave 1 Reliability Pack)
+
+standard:
+  id: timeout-standards
+  name: Timeout Standards
+  description: Timeout 標準 — 層級預算（cascading 0.8×）、deadline propagation、與 circuit-breaker 整合
+
+  meta:
+    version: "1.0.0"
+    updated: "2026-04-17"
+    status: trial
+    since: "2026-04-17"
+    expires: "2026-10-17"
+    source: XSPEC-067
+    borrowed_from: DEC-043
+    description: >
+      避免多層呼叫鏈中下層 timeout 大於上層（導致上層先 timeout 而下層仍在執行的資源浪費）。
+      透過 cascading 預算規則（每層 ≤ 0.8× 上層）與 deadline propagation（傳 absolute timestamp）
+      讓整條呼叫鏈都能精準 fail-fast。與 circuit-breaker 整合，timeout 計入 failure count。
+    scope: universal
+    industry_reference: "gRPC deadline propagation, Envoy timeout budgeting, Google SRE Book Ch.22"
+
+  guidelines:
+    - "多層呼叫的 timeout 必須逐層遞減，每下一層 ≤ 0.8 × 上層（預留 20% buffer）"
+    - "跨服務呼叫必須傳遞 deadline（absolute timestamp），不得只傳 relative duration"
+    - "收到請求後若 now > deadline，必須立即 fail-fast，禁止發起下游呼叫"
+    - "Timeout 觸發必須計入對應 circuit-breaker 的 failure count"
+    - "禁止下層 timeout 大於上層 timeout（違反 fail-fast，等同沒設 timeout）"
+
+  cascading_budget:
+    rule: "每下一層 timeout ≤ 0.8 × 上層 timeout"
+    rationale:
+      - "預留 20% buffer 給序列化、網路傳輸、重試等開銷"
+      - "避免上層先 timeout 而下層仍在執行（資源浪費 + 冷門錯誤）"
+      - "0.8 是業界經驗值（gRPC / Envoy 常用 0.7~0.85）"
+    example:
+      client_timeout_ms: 10000
+      gateway_timeout_ms: 8000       # 10000 * 0.8
+      service_a_timeout_ms: 6400     # 8000 * 0.8
+      downstream_db_timeout_ms: 5120 # 6400 * 0.8
+
+  deadline_propagation:
+    format: "absolute ISO-8601 timestamp（不是 relative duration）"
+    header_name: "X-Deadline"
+    rule_1: "發起呼叫前計算 deadline = now + timeout，寫入 header"
+    rule_2: "收到請求後立即檢查 now > deadline_header → 若是則 fail-fast（回 DEADLINE_EXCEEDED）"
+    rule_3: "向下游呼叫時 timeout = min(cascading_budget, deadline - now)，取兩者較小"
+    rationale: >
+      Relative duration（如 timeout=5s）無法在多層呼叫中累積扣除；
+      absolute timestamp 讓每一層都能精準計算剩餘時間，避免超時後仍發起無意義請求。
+
+  timeout_categories:
+    connect_timeout:
+      description: "建立 TCP / TLS 連線的時間上限"
+      default_ms: 5000
+      note: "通常比 request_timeout 短很多"
+    request_timeout:
+      description: "發送請求到收到完整回應的時間上限"
+      default_ms: 30000
+      note: "最常見的 timeout 類型；受 cascading 預算約束"
+    idle_timeout:
+      description: "連線閒置多久後關閉"
+      default_ms: 60000
+      note: "server 端設定；與 connection pool 配合"
+    total_deadline:
+      description: "含所有重試在內的整體上限"
+      default_ms: 60000
+      note: "retry × attempt_timeout 的總和不得超過此值"
+
+  circuit_breaker_integration:
+    rule_1: "每次 timeout 觸發視為一次失敗，計入 breaker 的 failure count"
+    rule_2: "連續 timeout 達 failureThreshold 時 breaker 進入 OPEN"
+    rule_3: "OPEN 狀態下的請求應套用極短 timeout（或直接 fail-fast），不走完整 request_timeout"
+
+  scenarios:
+    scenario_1_cascading_budget:
+      given: "Client timeout=10s，呼叫鏈 Client → Gateway → Service A → DB"
+      when: "設定各層 request_timeout"
+      then: "Gateway=8s, Service A=6.4s, DB=5.12s（每層 0.8×）"
+      note: "確保下層先 timeout，上層有機會捕獲並 fallback"
+
+    scenario_2_deadline_expired_on_receive:
+      given: "請求抵達 Service A 時 header X-Deadline 已過期"
+      when: "Service A 收到請求"
+      then: "立即回 DEADLINE_EXCEEDED，不呼叫 DB，不消耗資源"
+      note: "Deadline propagation 的 fail-fast 機制"
+
+    scenario_3_timeout_triggers_breaker:
+      given: "連續 3 次下游呼叫皆 timeout（failureThreshold=3）"
+      when: "第 4 次呼叫"
+      then: "circuit-breaker 進入 OPEN，立即回 CircuitOpenError"
+      note: "timeout 計入 breaker failure count，防止持續浪費資源"
+
+  error_codes:
+    TIMEOUT-001: "REQUEST_TIMEOUT — 單次請求超時"
+    TIMEOUT-002: "DEADLINE_EXCEEDED — 整體 deadline 已過，拒絕發起 / 處理請求"
+    TIMEOUT-003: "CASCADING_BUDGET_VIOLATION — 下層 timeout > 上層 timeout（配置錯誤）"
+
+  integration_points:
+    - "circuit-breaker.ai.yaml — timeout 計入 failure count，觸發 OPEN"
+    - "retry-standards.ai.yaml — 單次重試 timeout 不得超過 deadline - now"
+    - "failure-source-taxonomy.ai.yaml — timeout 對應 upstream_unavailable 或 tool_failure"
+    - "observability-standards（XSPEC-063 規劃中）— timeout 是 RED metric 的 Error 來源之一"

--- a/cli/standards-registry.json
+++ b/cli/standards-registry.json
@@ -1974,6 +1974,72 @@
       },
       "category": "core",
       "description": "Unified YAML-configurable Recovery Recipe format keyed by failureSource (XSPEC-045), with 6 built-in strategies and 5 default recipes, backward-compatible fallback."
+    },
+    {
+      "id": "retry-standards",
+      "name": "Retry Standards",
+      "nameZh": "重試策略標準",
+      "source": {
+        "human": "core/retry-standards.md",
+        "ai": "ai/standards/retry-standards.ai.yaml"
+      },
+      "category": "core",
+      "description": "Exponential backoff with full jitter, max_attempts cap, and failure-source-aware retry rules (DEC-043 Wave 1 Reliability, XSPEC-067, trial)."
+    },
+    {
+      "id": "timeout-standards",
+      "name": "Timeout Standards",
+      "nameZh": "Timeout 標準",
+      "source": {
+        "human": "core/timeout-standards.md",
+        "ai": "ai/standards/timeout-standards.ai.yaml"
+      },
+      "category": "core",
+      "description": "Cascading 0.8x per-layer timeout budget, deadline propagation via absolute timestamps, circuit-breaker integration (DEC-043 Wave 1 Reliability, XSPEC-067, trial)."
+    },
+    {
+      "id": "health-check-standards",
+      "name": "Health Check Standards",
+      "nameZh": "健康檢查標準",
+      "source": {
+        "human": "core/health-check-standards.md",
+        "ai": "ai/standards/health-check-standards.ai.yaml"
+      },
+      "category": "core",
+      "description": "Liveness/readiness/startup probe separation, deep health check scope (critical deps only), structured JSON response (DEC-043 Wave 1 Reliability, XSPEC-067, trial)."
+    },
+    {
+      "id": "standard-admission-criteria",
+      "name": "Standard Admission Criteria",
+      "nameZh": "標準納入條件",
+      "source": {
+        "human": "core/standard-admission-criteria.md",
+        "ai": "ai/standards/standard-admission-criteria.ai.yaml"
+      },
+      "category": "core",
+      "description": "Four admission gates (Evidence / Scope / Non-overlapping / AI-executable) for new UDS standards, with explicit rejection protocol (DEC-043 Wave 1 Governance Meta, XSPEC-070, trial)."
+    },
+    {
+      "id": "standard-lifecycle-management",
+      "name": "Standard Lifecycle Management",
+      "nameZh": "標準生命週期管理",
+      "source": {
+        "human": "core/standard-lifecycle-management.md",
+        "ai": "ai/standards/standard-lifecycle-management.ai.yaml"
+      },
+      "category": "core",
+      "description": "5-state lifecycle machine (Proposed/Trial/Active/Deprecated/Archived) with legal transitions and required frontmatter fields (DEC-043 Wave 1 Governance Meta, XSPEC-070, trial)."
+    },
+    {
+      "id": "skill-standard-alignment-check",
+      "name": "Skill-Standard Alignment Check",
+      "nameZh": "Skill 與 Standard 對齊檢查",
+      "source": {
+        "human": "core/skill-standard-alignment-check.md",
+        "ai": "ai/standards/skill-standard-alignment-check.ai.yaml"
+      },
+      "category": "core",
+      "description": "Skills must anchor to a Standard; Standards may exist without a Skill. Orphan-skill detection workflow (DEC-043 Wave 1 Governance Meta, XSPEC-070, trial)."
     }
   ]
 }

--- a/core/health-check-standards.md
+++ b/core/health-check-standards.md
@@ -1,0 +1,72 @@
+# Health Check Standards
+
+> **Source**: XSPEC-067 | **Driven by**: DEC-043 Wave 1 Reliability Pack | **Status**: Trial (2026-04-17 ~ 2026-10-17)
+
+## Overview
+
+健康檢查標準 — 業界常見錯誤是把 liveness 和 readiness 混用（健康檢查檢查外部依賴導致連鎖重啟）。本標準明確三種 probe 語意分離、定義深度 health check 的檢查範圍（僅關鍵依賴）、並規範結構化 JSON 回應以便下游自動化處理。與 observability 整合為 RED metric 的 Error 來源之一。
+
+## Key Principles
+
+- **Liveness 不碰外部依賴**：liveness 失敗會造成 pod 重啟；若依賴 DB，DB 故障時會造成所有 pod 連鎖重啟
+- **Readiness 僅檢關鍵依賴**：非關鍵依賴不納入，避免邊緣故障造成服務被下線
+- **慢啟動用 startup probe**：啟動完成後交棒給 liveness
+- **結構化 JSON 回應**：含 `status` / `dependencies` / `timestamp` / `version`
+- **作為 observability signal**：連續 fail 觸發 incident
+
+## Probe Types
+
+| Probe | Endpoint | Checks | On Fail | Threshold |
+|-------|----------|--------|---------|-----------|
+| **liveness** | `GET /health/live` | process 可回應 HTTP、內部 event loop | 重啟 pod | 3 failures |
+| **readiness** | `GET /health/ready` | 自身 API、DB ping（若必要）、關鍵下游 | 移出負載均衡（不重啟）| 3 failures |
+| **startup** | `GET /health/startup` | 啟動過程所需資源就緒 | 重啟 pod（啟動超時）| 30 failures |
+
+### Liveness Forbidden Checks
+
+- DB 連線（DB 壞時 liveness 失敗 → pod 重啟 → 啟動更多 client → DB 更壞）
+- 下游 API（會造成連鎖重啟）
+- 消息佇列
+
+## Depth Rules
+
+- **Shallow (liveness)**: process 是否可回應，不碰任何外部依賴
+- **Deep (readiness)**: 自身 API 路由、DB ping、關鍵下游 API ping（關鍵 = 沒有它服務就完全無法提供核心功能）
+
+## Response Format
+
+```json
+{
+  "status": "healthy | degraded | unhealthy",
+  "timestamp": "2026-04-17T10:00:00Z",
+  "uptime_seconds": 3600,
+  "dependencies": {
+    "database": {"status": "healthy", "latency_ms": 5, "last_check": "..."},
+    "upstream_api": {"status": "healthy", "latency_ms": 42, "last_check": "..."}
+  },
+  "version": "1.2.3"
+}
+```
+
+- HTTP 200 → healthy
+- HTTP 503 → unhealthy（至少一個關鍵依賴失敗）
+
+## Usage Examples
+
+- **Scenario 1 — Liveness 不檢 DB**：DB 連線池耗盡，liveness 仍回 200（liveness 不檢 DB），避免所有 pod 重啟
+- **Scenario 2 — Readiness 失敗**：關鍵下游 API 不可達，readiness 回 503，pod 移出 LB；process 不重啟
+- **Scenario 3 — Startup → Liveness 交棒**：服務需 60s 預熱快取，startup probe 前 60s 持續回 503，預熱完成改由 liveness 接手
+
+## Error Codes
+
+- `HC-001` — `HEALTH_CHECK_FAILED`（關鍵依賴失敗）
+- `HC-002` — `HEALTH_CHECK_TIMEOUT`（probe 本身超時）
+- `HC-003` — `INVALID_DEPENDENCY_SET`（readiness 檢查了非關鍵依賴，設計違規）
+
+## References
+
+- AI-optimized: [ai/standards/health-check-standards.ai.yaml](../ai/standards/health-check-standards.ai.yaml)
+- XSPEC-067: DEC-043 Wave 1 Reliability Pack 跨專案規格
+- DEC-043: UDS 覆蓋完整性路線圖（驅動來源）
+- Related: `deployment-standards`, `circuit-breaker`, observability-standards (XSPEC-063 規劃中)
+- Industry: Kubernetes probes, Microsoft eShop health checks, Google SRE Book Ch.6

--- a/core/retry-standards.md
+++ b/core/retry-standards.md
@@ -1,0 +1,62 @@
+# Retry Standards
+
+> **Source**: XSPEC-067 | **Driven by**: DEC-043 Wave 1 Reliability Pack | **Status**: Trial (2026-04-17 ~ 2026-10-17)
+
+## Overview
+
+重試策略標準 — 延伸既有 `circuit-breaker` 與 `failure-source-taxonomy`，補齊 retry 層的標準化規則。避免各元件各自實作重試造成行為不一致（無上限重試、無 jitter 導致 thundering herd）。與 `failure-source-taxonomy` 深度整合：依失敗類型決定是否重試、重試幾次、退避多久。
+
+## Key Principles
+
+- **指數退避加 full jitter**：所有重試邏輯必須使用 exponential + jitter，禁止固定間隔或無 jitter 的純指數
+- **明確重試上限**：必須有 `max_attempts`（預設 5），禁止無限重試
+- **依 failureSource 分類**：先查 `failure-source-taxonomy`，fail-fast 類別不得重試
+- **與 circuit-breaker 整合**：OPEN 狀態下 fail-fast，不消耗 `max_attempts`；`retry_exhausted` 計入 failure count
+- **重試可觀察**：每次重試上報 `retry_attempted` / `retry_exhausted` 遙測事件
+
+## Backoff Formula
+
+```
+wait_ms = min(cap_ms, base_ms * 2^attempt) * (0.5 + random() * 0.5)
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `base_ms` | 100 | 基礎退避時間 |
+| `cap_ms` | 30000 | 單次最長等待上限 |
+| `max_attempts` | 5 | 最多重試次數（不含第 0 次原始呼叫）|
+| `jitter_ratio` | 0.5 | Jitter 比例（±50%）|
+
+## Failure Source Retry Rules
+
+| Failure Source | Retry? | Max Attempts | Base ms | Note |
+|----------------|--------|--------------|---------|------|
+| `transient_network` | Yes | 5 | 100 | 短暫網路抖動 |
+| `rate_limit` | Yes | 3 | 1000 | 依 `Retry-After` 優先 |
+| `upstream_unavailable` | Yes | 3 | 500 | 連續失敗觸發 breaker OPEN |
+| `tool_failure` | Yes | 2 | 200 | 工具層失敗多半非 transient |
+| `prompt_delivery` | Yes | 2 | 100 | 超過改走 model_switch |
+| `authentication` | **No** | — | — | Fail-fast，重試不會變對 |
+| `validation` | **No** | — | — | Fail-fast，input 錯不改 |
+| `policy_violation` | **No** | — | — | Fail-fast，禁止繞過 |
+| `quota_exhausted` | **No** | — | — | Fail-fast，等 reset |
+
+## Usage Examples
+
+- **Scenario 1 — 指數退避**：`failure_source=transient_network`，已重試 2 次。第 3 次 wait 範圍 = `min(30000, 100 * 2^3) * [0.5..1.0] = 400~800ms`
+- **Scenario 2 — 401 Fail-fast**：API 回 401 Unauthorized，`failure_source=authentication`。立即 fail-fast，不進退避、不計入 breaker failure count
+- **Scenario 3 — Circuit Open 跳過**：breaker 為 OPEN，發起重試時立即回 `CircuitOpenError`，不消耗 `max_attempts`
+
+## Error Codes
+
+- `RETRY-001` — `RETRY_EXHAUSTED`（達到 max_attempts 仍失敗）
+- `RETRY-002` — `RETRY_SKIPPED_NON_RETRYABLE`（failureSource 屬 fail-fast 類別）
+- `RETRY-003` — `RETRY_SKIPPED_CIRCUIT_OPEN`（breaker OPEN 狀態下跳過）
+
+## References
+
+- AI-optimized: [ai/standards/retry-standards.ai.yaml](../ai/standards/retry-standards.ai.yaml)
+- XSPEC-067: DEC-043 Wave 1 Reliability Pack 跨專案規格
+- DEC-043: UDS 覆蓋完整性路線圖（驅動來源）
+- Related: `circuit-breaker`, `failure-source-taxonomy`, `timeout-standards`, `recovery-recipe-registry`
+- Industry: Netflix Hystrix retry, Google SRE Book Ch.22, AWS Architecture Blog — exponential backoff and jitter

--- a/core/skill-standard-alignment-check.md
+++ b/core/skill-standard-alignment-check.md
@@ -1,0 +1,79 @@
+# Skill-Standard Alignment Check
+
+> **Source**: XSPEC-070 | **Driven by**: DEC-043 Wave 1 Governance Meta Pack | **Status**: Trial (2026-04-17 ~ 2026-10-17)
+
+## Overview
+
+Skill 必有 Standard 作為錨點，Standard 可無 Skill；定期識別孤兒 Skill。Skill 是 UX 糖衣，Standard 是 standards-of-truth。若 Skill 無錨定 Standard，其行為就沒有明文依據，會隨作者口味飄移。本標準規範 Skill 必須指明錨定哪個 Standard，並定期識別「孤兒 Skill」（無對應 Standard），觸發補 Standard 的流程。反向允許 Standard 無 Skill（不強制每個 Standard 都造 Skill）。
+
+## Key Principles
+
+- **Skill 必錨 Standard**：所有 Skill frontmatter 必須含 `anchor_standard`（至少一個）
+- **Anchor 有效性**：必須指向 Trial / Active / Deprecated 狀態的標準 id
+- **Standard 可獨立**：Standard 無對應 Skill 是合法的（非錯誤，僅資訊）
+- **Orphan 治理**：無 anchor 的 Skill 列為 orphan，下一版必補或降 Proposed
+- **定期檢查**：建議季度執行 alignment check，產出 orphan 清單
+
+## Alignment Rules
+
+### Skill must have Standard
+
+- Frontmatter 必須含 `anchor_standard: <standard-id>` 或 `[<id1>, <id2>, ...]`
+- CI / pre-release 強制，缺欄位視為 fail
+- **例外**：純 utility Skill（如 docs-generator）可標 `anchor_standard: none` + 填 `utility_reason`
+
+### Standard may have Skill
+
+- Standard 獨立存在合法（可被 QualityGate / Agent 直接消費）
+- 強制每 Standard 造 Skill 會導致 Skill 庫膨脹
+- 範例：`immutability-first` 無對應 Skill 合法
+
+### Orphan Detection
+
+- 無 `anchor_standard` 的 Skill → orphan
+- 偵測後動作：列入季度報告 → 建立對應 Standard 的 XSPEC（走 admission 流程） → 無法建立則降 Skill 為 Proposed
+
+## Known Orphans (as of 2026-04)
+
+本 XSPEC-070 識別的現存 orphan Skill（由 XSPEC-063~069 補齊）：
+
+| Skill | Needs Standard | Planned XSPEC |
+|-------|----------------|---------------|
+| `slo-assistant` | slo-standards | XSPEC-063 |
+| `runbook-assistant` | runbook-standards | XSPEC-064 |
+| `incident-response-assistant` | incident-response-standards | XSPEC-063 |
+| `observability-assistant` | observability-standards | XSPEC-063 |
+| `metrics-dashboard-assistant` | metrics-dashboard-standards | XSPEC-063 |
+| `ci-cd-assistant` | ci-cd-standards | XSPEC-066 |
+
+清單將隨 XSPEC-063~069 實作逐步清空。
+
+## Alignment Check Workflow
+
+1. 掃描 `skills/**/*.md` 抽取 frontmatter `anchor_standard`
+2. 掃描 `ai/standards/*.ai.yaml` 抽取所有 `standard.id`
+3. 計算差集：Skill without anchor → orphan 清單
+4. 計算反向差集：Standard without Skill → informational
+5. 驗證 anchor 指向存在且非 Archived 的 id
+6. 產出 `alignment-report.json` / `alignment-report.md`
+
+## Usage Examples
+
+- **Scenario 1 — 健康對齊**：`retry-assistant` frontmatter 含 `anchor_standard: retry-standards`，指向 Trial 狀態標準 → 檢查通過
+- **Scenario 2 — Orphan 偵測**：`slo-assistant` 無 `anchor_standard` → 列入 orphan 清單，報告標註「需建立 slo-standards 或降 Proposed」
+- **Scenario 3 — 孤立 Standard 合法**：`immutability-first.ai.yaml` 存在但無 Skill → `standalone-standard` 計數 +1，非錯誤
+
+## Error Codes
+
+- `ALIGN-001` — `SKILL_MISSING_ANCHOR`
+- `ALIGN-002` — `BROKEN_ANCHOR`（指向不存在的 standard id）
+- `ALIGN-003` — `ARCHIVED_ANCHOR`（指向已 Archived 的標準）
+- `ALIGN-004` — `UTILITY_MISSING_REASON`
+
+## References
+
+- AI-optimized: [ai/standards/skill-standard-alignment-check.ai.yaml](../ai/standards/skill-standard-alignment-check.ai.yaml)
+- XSPEC-070: DEC-043 Wave 1 Governance Meta Pack 跨專案規格
+- DEC-043: UDS 覆蓋完整性路線圖（XSPEC-063~069 目的之一即清空本標準識別的 orphan 清單）
+- Related: `standard-admission-criteria`, `standard-lifecycle-management`
+- Internal: AsiaOstrich DEC-043 七主題缺口分析（slo/runbook/observability 等 40+ Skill 部分無 Standard 錨點）

--- a/core/standard-admission-criteria.md
+++ b/core/standard-admission-criteria.md
@@ -1,0 +1,84 @@
+# Standard Admission Criteria
+
+> **Source**: XSPEC-070 | **Driven by**: DEC-043 Wave 1 Governance Meta Pack | **Status**: Trial (2026-04-17 ~ 2026-10-17)
+
+## Overview
+
+新標準納入 UDS 的四項條件。在 DEC-043 提出 60+ 候選新標準的背景下，需要一個明文的納入檢查清單，避免標準庫膨脹（重疊、未使用）與降低品質。本標準是 UDS 的治理層 meta 標準 — 用來「決定標準的標準」。每個候選新標準必須通過四項條件才能從 Proposed 進入 Trial。
+
+## Key Principles
+
+- **四項硬性條件**：所有候選新標準必須同時通過 Evidence / Scope / Non-overlapping / AI-executable
+- **拒絕理由必須具體**：不得以「不合適」之類籠統用詞結案，必須指出未通過的 criterion
+- **Admission ≠ Active**：通過 admission 僅代表可進 Trial，不代表直接 Active
+- **Self-applicability**：本標準也必須符合四項條件
+- **Backward compat**：既有 66 個 Active 標準不溯及既往
+
+## The Four Criteria
+
+### 1. Evidence（具體場景）
+
+至少 2 個具體使用場景（非 hypothetical）：
+
+- 場景來自實際專案、Repo、論文或 DEC 記錄
+- 描述具體（可舉出檔案 / 函式 / commit）
+- 至少 1 個來自 AsiaOstrich 內部痛點或外部產業佐證
+
+**拒絕範例**：「未來可能用到」— 無具體場景
+
+### 2. Scope（明確作用域）
+
+- `meta.scope` 標示 `universal` / `partial` / `uds-specific`
+- frontmatter 列出適用的活動類型（development / deployment / testing）
+- 若為 partial 或 uds-specific，說明不通用的原因
+
+**拒絕範例**：「所有場合都適用」— 過度泛化
+
+### 3. Non-overlapping（無重大重疊）
+
+與既有 UDS 標準內容重複 < 30%：
+
+- 列出最接近的 3 個既有標準，說明差異
+- 若有 ≥ 30% 重疊，應改為擴充既有標準
+- 明確定義 `integration_points`
+
+**拒絕範例**：與 `retry-standards` 80% 內容重複 — 應合併
+
+### 4. AI-executable（AI 可消費）
+
+至少一個 DevAP QualityGate / VibeOps Agent prompt / Skill 能消費：
+
+- 定義清楚的 guidelines（每條可驗證）
+- 至少 2 個 Given-When-Then scenarios
+- 需型別時提供 interface / types 區塊
+- 明確的 `integration_points`
+
+**拒絕範例**：只有抽象原則，無任何 AI 可執行的規則
+
+## Rejection Protocol
+
+1. 拒絕理由必須指出未通過的 criterion（evidence / scope / non-overlapping / ai-executable）
+2. 拒絕記錄寫入 `cross-project/decisions/` 或 DEC 的 rejection log
+3. 候選者可依理由修正後重新申請（不永久封鎖）
+4. 若拒絕理由涉及重疊，應建議改為擴充既有標準
+
+## Usage Examples
+
+- **Scenario 1 — 通過**：`retry-standards` 申請。Evidence（XSPEC-067 Scenario 1-1/1-2）、Scope（universal）、Non-overlapping（與 circuit-breaker 互補）、AI-executable（9 guidelines + 3 scenarios）全通過 → 進入 Trial
+- **Scenario 2 — 因重疊拒絕**：`advanced-retry-with-jitter` 申請。與 `retry-standards` 重疊 > 30% → 拒絕，建議改為 Phase 2 擴充
+- **Scenario 3 — 因證據不足拒絕**：`universal-best-practices` 申請。僅「未來可能用到」類描述 → 拒絕，要求至少 2 個已發生案例
+
+## Error Codes
+
+- `ADMISSION-001` — `MISSING_EVIDENCE`
+- `ADMISSION-002` — `SCOPE_UNDEFINED`
+- `ADMISSION-003` — `OVERLAP_EXCEEDED`（> 30%）
+- `ADMISSION-004` — `NOT_AI_EXECUTABLE`
+
+## References
+
+- AI-optimized: [ai/standards/standard-admission-criteria.ai.yaml](../ai/standards/standard-admission-criteria.ai.yaml)
+- XSPEC-070: DEC-043 Wave 1 Governance Meta Pack 跨專案規格
+- DEC-043: UDS 覆蓋完整性路線圖（本標準是 Wave 1 前置條件）
+- Related: `standard-lifecycle-management`, `skill-standard-alignment-check`, `adr-standards`
+- Industry: IETF RFC admission criteria, Python PEP process, W3C Recommendation Track

--- a/core/standard-lifecycle-management.md
+++ b/core/standard-lifecycle-management.md
@@ -1,0 +1,94 @@
+# Standard Lifecycle Management
+
+> **Source**: XSPEC-070 | **Driven by**: DEC-043 Wave 1 Governance Meta Pack | **Status**: Trial (2026-04-17 ~ 2026-10-17)
+
+## Overview
+
+UDS 標準生命週期狀態機。既有 66 個標準無明確狀態管理：新增標準沒有試驗期、過時標準無棄用路徑、廢棄標準仍被引用。本標準建立五狀態機（Proposed / Trial / Active / Deprecated / Archived）與合法轉移規則，並規範所有 `.ai.yaml` 標準必須在 frontmatter 標示 `status` / `since` / `expires` / `supersedes`。
+
+## Key Principles
+
+- **所有標準必有狀態**：frontmatter 必須包含 `status` 和 `since`
+- **Trial 必有期限**：`expires` 預設 since + 6 months
+- **Deprecated 必有替代**：`supersedes` 指向替代標準 id 或遷移文件
+- **禁止反向轉移**：Active → Proposed、Archived → Active 均無意義
+- **逾期自動 Archived**：Trial 到期未決則自動歸檔
+
+## States
+
+| State | Description | Skill-referenceable? |
+|-------|-------------|----------------------|
+| **Proposed** | 草案階段，未通過 admission | No |
+| **Trial** | 批准但試驗中（預設 6 個月）| Yes（標註 trial）|
+| **Active** | 全面採用，standard-of-truth | Yes |
+| **Deprecated** | 標記棄用，必須提供 `supersedes` | Yes（Skill 應警示）|
+| **Archived** | 已移除，僅保留歷史 | No |
+
+## Legal Transitions
+
+```
+Proposed ──(admission passed)──→ Trial
+Trial    ──(validated)──────────→ Active
+Trial    ──(expired/rejected)───→ Archived
+Active   ──(superseded)─────────→ Deprecated
+Deprecated ──(migration done)───→ Archived
+```
+
+**禁止的轉移**：
+
+- Active → Proposed（無意義）
+- Archived → Active（應重新申請 admission）
+- Deprecated → Active（應重新 Trial）
+- Proposed → Active（須先 Trial）
+
+## Frontmatter Required Fields
+
+### Always Required
+
+- `status`: proposed | trial | active | deprecated | archived
+- `since`: ISO-8601（進入當前狀態的日期）
+- `version`: semver 字串
+
+### Conditional
+
+| Field | When |
+|-------|------|
+| `expires` | `status = trial`（預設 since + 6 months）|
+| `supersedes` | `status = deprecated`（替代標準 id 或遷移文件路徑）|
+| `migration_guide` | `status = deprecated`（相對路徑，選填但強烈建議）|
+
+## Usage Examples
+
+- **Scenario 1 — Trial → Active**：`retry-standards` 處於 trial。2026-08-01 審視發現 DevAP Fix Loop 和 VibeOps Builder 均採用且無重大缺陷 → 轉 Active，`since=2026-08-01`，移除 `expires`
+- **Scenario 2 — Trial 逾期自動 Archived**：某標準 trial 期限 2026-10-17 到期未通過驗證 → 狀態轉 Archived，記錄原因
+- **Scenario 3 — Deprecated 帶遷移**：`legacy-retry-logic` 被 `retry-standards` 取代 → `status=deprecated, supersedes=retry-standards, migration_guide=docs/migrations/retry-v1-to-v2.md`；Skill 使用時顯示警告
+
+## Telemetry Event
+
+`standard_state_change`:
+
+```
+{
+  standard_id: string,
+  from_state: proposed|trial|active|deprecated|archived,
+  to_state:   proposed|trial|active|deprecated|archived,
+  reason: string,
+  timestamp: ISO-8601
+}
+```
+
+## Error Codes
+
+- `LIFECYCLE-001` — `MISSING_STATUS`
+- `LIFECYCLE-002` — `MISSING_EXPIRES`（trial 狀態）
+- `LIFECYCLE-003` — `MISSING_SUPERSEDES`（deprecated 狀態）
+- `LIFECYCLE-004` — `FORBIDDEN_TRANSITION`
+- `LIFECYCLE-005` — `TRIAL_EXPIRED`（期限已過但未決策）
+
+## References
+
+- AI-optimized: [ai/standards/standard-lifecycle-management.ai.yaml](../ai/standards/standard-lifecycle-management.ai.yaml)
+- XSPEC-070: DEC-043 Wave 1 Governance Meta Pack 跨專案規格
+- DEC-043: UDS 覆蓋完整性路線圖（驅動來源）
+- Related: `standard-admission-criteria`, `skill-standard-alignment-check`, `adr-standards`
+- Industry: IETF RFC lifecycle (Proposed → Draft → Internet Standard), Python PEP states, W3C Recommendation Track

--- a/core/timeout-standards.md
+++ b/core/timeout-standards.md
@@ -1,0 +1,63 @@
+# Timeout Standards
+
+> **Source**: XSPEC-067 | **Driven by**: DEC-043 Wave 1 Reliability Pack | **Status**: Trial (2026-04-17 ~ 2026-10-17)
+
+## Overview
+
+Timeout 標準 — 避免多層呼叫鏈中下層 timeout 大於上層（導致上層先 timeout 而下層仍在執行的資源浪費）。透過 cascading 預算規則（每層 ≤ 0.8× 上層）與 deadline propagation（傳 absolute timestamp）讓整條呼叫鏈精準 fail-fast。與 `circuit-breaker` 整合，timeout 計入 failure count。
+
+## Key Principles
+
+- **Cascading 預算**：多層呼叫的 timeout 必須逐層遞減，每下一層 ≤ `0.8 × 上層`（預留 20% buffer）
+- **Deadline Propagation**：跨服務呼叫必須傳遞 deadline（absolute timestamp），不得只傳 relative duration
+- **Fail-fast on Expired**：收到請求後若 `now > deadline`，立即 fail-fast，禁止發起下游呼叫
+- **Breaker 整合**：timeout 觸發計入對應 circuit-breaker 的 failure count
+- **禁止倒置**：下層 timeout 大於上層 timeout 等同沒設 timeout，配置違規
+
+## Cascading Budget Example
+
+```
+Client timeout         = 10000 ms
+Gateway timeout        =  8000 ms   (10000 × 0.8)
+Service A timeout      =  6400 ms   (8000  × 0.8)
+Downstream DB timeout  =  5120 ms   (6400  × 0.8)
+```
+
+0.8 為業界經驗值（gRPC / Envoy 常用 0.7~0.85），預留 20% buffer 給序列化、網路傳輸、重試開銷。
+
+## Deadline Propagation
+
+- Header: `X-Deadline`
+- Format: absolute ISO-8601 timestamp（不是 relative duration）
+- 發起呼叫前：`deadline = now + timeout`，寫入 header
+- 收到請求後：立即檢查 `now > deadline_header`，若是則回 `DEADLINE_EXCEEDED`
+- 向下游呼叫：`timeout = min(cascading_budget, deadline - now)`
+
+## Timeout Categories
+
+| Category | Default ms | Purpose |
+|----------|------------|---------|
+| `connect_timeout` | 5000 | 建立 TCP / TLS 連線 |
+| `request_timeout` | 30000 | 發送請求到收到完整回應 |
+| `idle_timeout` | 60000 | 連線閒置多久後關閉 |
+| `total_deadline` | 60000 | 含所有重試的整體上限 |
+
+## Usage Examples
+
+- **Scenario 1 — Cascading 預算**：Client 10s → Gateway 8s → Service A 6.4s → DB 5.12s，確保下層先 timeout，上層有機會 fallback
+- **Scenario 2 — Deadline 過期**：請求抵達 Service A 時 `X-Deadline` 已過期，立即回 `DEADLINE_EXCEEDED`，不呼叫 DB
+- **Scenario 3 — Timeout 觸發 breaker**：連續 3 次下游呼叫皆 timeout（failureThreshold=3），第 4 次 breaker 進入 OPEN
+
+## Error Codes
+
+- `TIMEOUT-001` — `REQUEST_TIMEOUT`（單次請求超時）
+- `TIMEOUT-002` — `DEADLINE_EXCEEDED`（整體 deadline 已過）
+- `TIMEOUT-003` — `CASCADING_BUDGET_VIOLATION`（下層 > 上層，配置錯誤）
+
+## References
+
+- AI-optimized: [ai/standards/timeout-standards.ai.yaml](../ai/standards/timeout-standards.ai.yaml)
+- XSPEC-067: DEC-043 Wave 1 Reliability Pack 跨專案規格
+- DEC-043: UDS 覆蓋完整性路線圖（驅動來源）
+- Related: `circuit-breaker`, `retry-standards`, `failure-source-taxonomy`
+- Industry: gRPC deadline propagation, Envoy timeout budgeting, Google SRE Book Ch.22


### PR DESCRIPTION
## Summary

- 新增 **DEC-043 Wave 1** 共 6 個 Trial 狀態標準（.ai.yaml + .md + registry 三方同步）
- **XSPEC-067 Reliability Phase 1**: `retry-standards`, `timeout-standards`, `health-check-standards`
- **XSPEC-070 治理層 Meta Phase 1**: `standard-admission-criteria`, `standard-lifecycle-management`, `skill-standard-alignment-check`
- 治理層 Meta 作為後續 7 個主題標準包（Wave 2-4）的**前置條件**

## 動機

UDS 盤點後識別 SDLC 八大覆蓋缺口（SRE / CI-CD / IaC / 合規 / Reliability / 資料工程 / 產品層 / 治理層）。本 PR 為 Wave 1 實作，延伸既有 reliability 基礎（circuit-breaker / failure-source-taxonomy / recovery-recipe-registry / immutability-first）並建立治理 Meta 層。

## 規格來源（跨專案）

- **Meta 路線圖**: [DEC-043](https://github.com/AsiaOstrich/dev-platform/blob/main/cross-project/decisions/DEC-043-uds-coverage-completeness-roadmap.md)
- **Reliability 規格**: [XSPEC-067](https://github.com/AsiaOstrich/dev-platform/blob/main/cross-project/specs/XSPEC-067-uds-reliability-pack.md)
- **治理 Meta 規格**: [XSPEC-070](https://github.com/AsiaOstrich/dev-platform/blob/main/cross-project/specs/XSPEC-070-uds-governance-meta-standards-pack.md)

## 驗證

- ✅ `check-standards-sync.sh` pre-commit hook 通過（核心 ↔ ai/standards ↔ registry 三方一致）
- ✅ 6 個新標準於 `cli/standards-registry.json` 已註冊
- ✅ `README.md` stats table 由 72 → 78

## 變更統計

| 類別 | 數量 |
|------|:---:|
| 新增 `.ai.yaml` | 6 檔（104–144 行） |
| 新增 `.md` | 6 檔（62–94 行） |
| Registry entries | 6 筆（+66 行） |
| 總計 | **14 檔 / 1269 行** |

## Test plan

- [ ] 本地 clone 後執行 `./scripts/check-standards-sync.sh` 確認無新增不同步
- [ ] 抽樣檢查 `retry-standards.ai.yaml` 的 scenarios 與 XSPEC-067 Requirement 1 對齊
- [ ] 抽樣檢查 `standard-lifecycle-management.ai.yaml` 的五狀態定義與 XSPEC-070 Requirement 2 一致
- [ ] 確認 `meta.status: trial` + `expires` 欄位符合 `standard-lifecycle-management` 自身定義的 Trial 規範（自我相容）
- [ ] 確認新標準均引用回 `DEC-043` 與對應 XSPEC（trace 回向完整）

## 後續

- **Wave 1 Phase 2**（可選擇延續本 PR 或另開）：idempotency-standards、graceful-degradation、bulkhead-standards、resilience-testing
- **Wave 2**（2026-05-15 後）：XSPEC-063 SRE + XSPEC-064 CI/CD

🤖 Generated with [Claude Code](https://claude.com/claude-code)