### PR TITLE
feat(standards): three incident-sourced additions — versioning R2/R3, refactoring copy-drift, mock-boundary background seam (#138 #142 #143)

### DIFF
--- a/ai/standards/mock-boundary.ai.yaml
+++ b/ai/standards/mock-boundary.ai.yaml
@@ -3,14 +3,17 @@
 
 id: mock-boundary
 meta:
-  version: "1.1.0"
-  updated: "2026-05-13"
+  version: "1.2.0"
+  updated: "2026-07-01"
   source: core/mock-boundary.md
   description: >
     Rules defining what can and cannot be mocked to prevent hollow tests —
     tests that pass while the real system is broken.
     v1.1.0: Added Level 1/Level 2 mock layer distinction and external
     dependency testability matrix template (XSPEC-204).
+    v1.2.0: Added injectable background execution as a seam (parallel to clock
+    injection) — allowed background-runner seam, no-poll/sleep rule, and the
+    poll/sleep-for-background-result anti-pattern (issue #143).
 
 # ─────────────────────────────────────────────────────────
 # Mock Levels (v1.1.0)
@@ -150,6 +153,31 @@ allowed:
       // 1. The DB layer has its own integration tests
       // 2. The service test focuses on service logic (not DB behavior)
 
+  - category: In-Process Background Execution (via injectable runner)
+    description: >
+      Fire-and-forget dispatch — Task.Run, unawaited promises, setTimeout,
+      goroutines, thread-pool/executor submission, asyncio.create_task
+    reason: >
+      Background dispatch is a seam, exactly like the system clock. Inject a
+      runner so the test can drive the work to deterministic, awaited completion
+      and assert on success/exception/retry — instead of polling or sleeping.
+    implementation: >
+      Abstract dispatch behind a small interface (e.g. IBackgroundTaskRunner /
+      BackgroundDispatcher). Production keeps true fire-and-forget semantics;
+      the test double runs the work inline and tracks the Task/promise, exposing
+      a handle the test can await before asserting.
+    example: |
+      // Production: real fire-and-forget — returns immediately, work runs detached
+      class FireAndForgetDispatcher implements BackgroundDispatcher {
+        dispatch(work: () => Promise<void>): void { void work() }
+      }
+      // Test: inline + tracked so the test can await deterministic completion
+      class DeterministicDispatcher implements BackgroundDispatcher {
+        private tasks: Promise<void>[] = []
+        dispatch(work: () => Promise<void>): void { this.tasks.push(work()) }
+        async settle(): Promise<void> { await Promise.all(this.tasks) }
+      }
+
 # ─────────────────────────────────────────────────────────
 # Forbidden Mocks
 # ─────────────────────────────────────────────────────────
@@ -253,6 +281,15 @@ anti_patterns:
     description: DB mock returns hardcoded data, hiding query logic errors
     problem: Schema migrations, wrong predicates, missing joins — all invisible
 
+  - name: Poll/Sleep for Background Result
+    description: >
+      Sleeping or polling to wait for in-process fire-and-forget work
+      (Task.Run, unawaited promise, setTimeout, goroutine) to finish
+    problem: >
+      The race is still there — the timeout only hides it most of the time while
+      slowing the whole suite; on a shared runner it leaks flakiness into other
+      MRs' CI. Same class of anti-pattern as depending on wall-clock time.
+
 # ─────────────────────────────────────────────────────────
 # Rules
 # ─────────────────────────────────────────────────────────
@@ -295,6 +332,15 @@ rules:
     instruction: >
       AI-generated tests frequently over-mock. Apply all detection_patterns checks.
       If any hollow test indicator triggers, rewrite the mocking strategy.
+    priority: required
+
+  - id: no-poll-sleep-for-background-work
+    trigger: test asserts a fire-and-forget side effect (Task.Run, unawaited promise, setTimeout, goroutine, executor)
+    instruction: >
+      Never poll or sleep to wait for in-process background work. Inject a
+      deterministic runner (e.g. IBackgroundTaskRunner / BackgroundDispatcher)
+      whose test double runs the work inline and tracks the Task/promise; await
+      the tracked task, then assert on success, exception, or retry.
     priority: required
 
   - id: level-2-stub-server-rules

--- a/ai/standards/refactoring-standards.ai.yaml
+++ b/ai/standards/refactoring-standards.ai.yaml
@@ -3,8 +3,8 @@
 
 id: refactoring-standards
 meta:
-  version: "2.0.0"
-  updated: "2026-01-21"
+  version: "2.2.0"
+  updated: "2026-07-01"
   source: core/refactoring-standards.md
   guide: core/guides/refactoring-guide.md
   description: Refactoring guidelines with tactical, strategic, and safety strategies including decision matrix
@@ -292,9 +292,14 @@ metrics:
     - metric: Coupling
       measurement: Module dependencies count
       target: Reduce dependencies
-    - metric: Code Duplication
+    - metric: Code Duplication (textual)
       measurement: Duplicate percentage
       target: "< 3%"
+      note: Detects textual duplication only; cannot detect semantic duplication (see semantic_duplication)
+    - metric: Semantic Duplication
+      measurement: Golden / architecture test
+      target: 0 unmanaged domain facts
+      note: Static analysis cannot detect the same domain fact re-implemented across call sites
 
   test_quality:
     - metric: Test Coverage
@@ -313,6 +318,40 @@ metrics:
     - metric: Change Failure Rate
       source: Rollback count
       expected: Should decrease
+
+# Semantic Duplication & Copy-Drift (issue #142)
+semantic_duplication:
+  anti_pattern:
+    id: copy-drift
+    name: Copy-Drift
+    definition: Same domain fact implemented in multiple places, OR a derived value persisted without an enforced binding to its source, so the copies drift apart independently
+    why_undetected: Copies are not byte-identical (paraphrased logic, formula right in one place and wrong in another), so textual-duplication metrics report nothing
+    symptoms:
+      - List view disagrees with detail view
+      - Stored counter double-counts because one update path's decrement/rollback branch was skipped or commented out
+      - Same formula gives different answers in different modules
+      - Scope over-reach where one path adjusts an aggregate others also touch
+
+  pattern:
+    id: single-source-of-truth
+    name: Single Source of Truth / Derive-Don't-Duplicate
+    rules:
+      - one_unit_per_fact: Extract each domain fact into a single classifier/calculator/resolver; every call site calls it, no re-implementations or paraphrases
+      - derive_dont_store: Prefer computing on read over persisting a second copy; a value always derived cannot drift
+      - aggregate_as_projection: If an aggregate must be stored, treat it as a projection of its detail rows and recompute it at a single choke point (e.g. SaveChanges interceptor or one shared recompute() function) so every write path (incl. async jobs and failure write-backs) stays consistent
+      - never_incremental_adjust: Never let an individual path apply incremental "col = col + delta" to a stored aggregate; that is how decrement/rollback branches get skipped and counters diverge
+      - lock_with_tests: Use a golden test to pin the single source of truth, and an architecture test that fails if the rule is redefined anywhere else
+
+  intentional_divergence_registry:
+    when: New system intentionally diverges from legacy behavior (e.g. legacy function returns X but legacy pipeline reconciles it to Y; the port folds that reconciliation into the single unit so it returns Y directly)
+    actions:
+      - Register each intentional divergence (legacy behavior, new behavior, rationale, owning fact)
+      - Pin the new behavior with a golden test so a future "correction" back to legacy fails the build
+      - Feed the registry into any differential test against legacy so the divergence is treated as expected, not a regression
+
+  adopter_notes:
+    - Per-function legacy-vs-new diffing produces candidates, not verdicts; adjudicate each against the ENTIRE legacy pipeline (which may already reconcile the difference downstream) before calling it a bug
+    - Extract legacy function bodies programmatically / token-based (not by hand) to avoid reintroducing transcription errors
 
 # Team Collaboration
 team_collaboration:
@@ -456,8 +495,34 @@ rules:
     instruction: Keep PRs under 200 lines; split larger refactorings
     priority: recommended
 
+  - id: single-source-of-truth
+    trigger: same domain fact (classification, rule, calculation) needed at multiple call sites
+    instruction: Extract one shared classifier/calculator/resolver and call it everywhere; never re-implement or paraphrase the fact
+    priority: required
+
+  - id: derive-dont-duplicate
+    trigger: a derived value (aggregate, counter, denormalized field) is being persisted
+    instruction: Prefer deriving on read; if it must be stored, recompute it as a projection at a single choke point and never apply incremental col = col + delta adjustments per write path
+    priority: required
+
+  - id: lock-single-source-with-tests
+    trigger: after establishing a single source of truth for a domain fact
+    instruction: Add a golden test to pin it and an architecture test that fails if the rule is redefined elsewhere
+    priority: recommended
+
+  - id: register-intentional-divergence
+    trigger: new system intentionally diverges from legacy behavior during a port/migration
+    instruction: Record it in an intentional-divergence registry, pin with a golden test, and feed differential tests so it is treated as expected not a regression
+    priority: required
+
+  - id: adjudicate-diff-against-pipeline
+    trigger: reviewing per-function legacy-vs-new diffs
+    instruction: Treat diffs as candidates only; adjudicate each against the entire legacy pipeline before calling it a bug, and extract legacy bodies programmatically to avoid transcription errors
+    priority: recommended
+
 related_standards:
   - test-driven-development.md
   - testing-standards.md
+  - test-governance.md
   - code-review-checklist.md
   - checkin-standards.md

--- a/ai/standards/versioning.ai.yaml
+++ b/ai/standards/versioning.ai.yaml
@@ -13,8 +13,8 @@ standard:
     - "Use pre-release identifiers (alpha, beta, rc)"
 
   meta:
-    version: "2.1.0"
-    updated: "2026-06-24"
+    version: "2.2.0"
+    updated: "2026-07-01"
     source: core/versioning.md
     description: Semantic Versioning (SemVer) for software releases
 
@@ -121,6 +121,7 @@ standard:
         check_items:
           - Service running normally
           - API returns correct version
+          - "Build-identity endpoint (/version or /health) returns commit sha matching the deployed artifact (not just version)"
           - No fatal errors in logs
           - Functionality verification passed
 
@@ -148,6 +149,27 @@ standard:
     - id: dry-run-test
       trigger: deploying upgrade
       instruction: Must not skip dry-run test
+      priority: required
+    - id: git-height-versioning-polyglot
+      trigger: choosing version automation for a polyglot / .NET / JVM project
+      instruction: >
+        Use git-height-derived versioning (MinVer / Nerdbank.GitVersioning / GitVersion)
+        so the version is derived from git tag + commit height and collisions are
+        structurally impossible; reserve semantic-release / standard-version for Node/npm
+        projects
+      priority: recommended
+    - id: build-identity-must-expose-sha
+      trigger: deploying a service
+      instruction: >
+        Deployed services MUST expose build identity (version + commit sha + build time)
+        via a queryable endpoint (/version or embedded in /health); the sha MUST be
+        verifiable against the deployed artifact, not self-reported
+      priority: required
+    - id: verify-sha-post-release
+      trigger: post-release verification
+      instruction: >
+        Assert the build-identity endpoint returns a commit sha matching the deployed
+        artifact, not merely the correct version number
       priority: required
 
 physical_spec:

--- a/core/mock-boundary.md
+++ b/core/mock-boundary.md
@@ -1,7 +1,7 @@
 # Mock Boundary Standards
 
-**Version**: 1.0.0
-**Last Updated**: 2026-05-04
+**Version**: 1.1.0
+**Last Updated**: 2026-07-01
 **Applicability**: All software projects with unit and integration tests
 **Scope**: universal
 **Industry Standards**: ISTQB Foundation (Test Doubles), xUnit Patterns (Gerard Meszaros)
@@ -46,6 +46,7 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 | Environment variables | `process.env.NODE_ENV`, `process.env.LICENSE_KEY` | Enables config variation |
 | File system (unit tests only) | `fs.readFile`, `fs.writeFile` | Avoids I/O in fast unit tests |
 | Cross-module boundaries (with IT counterpart) | Other modules' public APIs | Isolates unit under test |
+| In-process background execution (via injectable runner) | `Task.Run`, unawaited promises, `setTimeout`, goroutines, thread-pool dispatch | Injecting a runner seam lets tests await deterministic completion, eliminating the race |
 
 ---
 
@@ -57,6 +58,46 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 | Database in IT/flow/E2E tests | `vi.mock('./db/client.js')` in integration tests | Hides query bugs, schema issues |
 | HTTP framework internals | `vi.mock('express')` | Real routing may be broken |
 | Security controls | Always-pass auth middleware stub | Security regressions invisible |
+
+---
+
+## Injectable Background Execution
+
+Fire-and-forget background work (a `Task.Run`, an unawaited promise, a `setTimeout`, a goroutine, a `java.util.concurrent` executor submission, or `asyncio.create_task`) is a **seam**, exactly like the system clock. Just as you inject a clock instead of reading wall-clock time, you inject the background dispatcher instead of spawning work directly. This lets a test drive the work to a **deterministic, awaited completion** and assert on its outcome (success, exception, or retry) — no polling, no sleeping, no race.
+
+Abstract the dispatch behind a small interface (e.g. `IBackgroundTaskRunner` / `BackgroundDispatcher`), then provide two implementations:
+
+- **Production**: preserves true fire-and-forget semantics — dispatch returns immediately and the work runs detached.
+- **Test**: runs the work **inline** and **tracks the underlying Task/promise**, exposing a handle the test can `await` so completion (and any failure) is observable.
+
+Language-neutral sketch (TypeScript pseudo-code):
+
+```typescript
+// Seam — injected wherever background work is dispatched
+interface BackgroundDispatcher {
+  dispatch(work: () => Promise<void>): void
+}
+
+// Production: real fire-and-forget — returns immediately, work runs detached
+class FireAndForgetDispatcher implements BackgroundDispatcher {
+  dispatch(work: () => Promise<void>): void {
+    void work() // intentionally not awaited
+  }
+}
+
+// Test: inline execution + tracked tasks so tests can await completion
+class DeterministicDispatcher implements BackgroundDispatcher {
+  private readonly tasks: Promise<void>[] = []
+  dispatch(work: () => Promise<void>): void {
+    this.tasks.push(work()) // start inline, keep the handle
+  }
+  async settle(): Promise<void> {
+    await Promise.all(this.tasks) // test awaits deterministic completion
+  }
+}
+```
+
+The test injects `DeterministicDispatcher`, exercises the code under test, then `await dispatcher.settle()` before asserting on the result — the background side effect is now fully observable and deterministic.
 
 ---
 
@@ -78,6 +119,7 @@ Before submitting a test file, check:
 - **Orphan Mock**: Cross-module mock with no integration test counterpart
 - **Security Bypass Mock**: Auth/permission logic replaced with pass-through stub
 - **Database Mock Cascade**: DB returns hardcoded data, hiding real query errors
+- **Poll/Sleep for Background Result**: Sleeping or polling to wait for fire-and-forget work to finish. The race is still there — the timeout merely hides it most of the time while slowing the whole suite and, on a shared runner, leaking flakiness into other MRs' CI. Inject a deterministic runner and await the tracked task instead.
 
 ---
 
@@ -90,6 +132,7 @@ Before submitting a test file, check:
 | IT counterpart | Mocking cross-module boundary | Ensure corresponding IT exists |
 | No security mock | Test involves auth/permissions | Use real test user + real token |
 | Hollow review | Mock count ≥ import count | Add output-value assertion |
+| No poll/sleep for background work | Test asserts a fire-and-forget side effect | Inject deterministic runner; await the tracked task |
 
 ---
 
@@ -98,3 +141,12 @@ Before submitting a test file, check:
 - **testing**: Mock boundary rules apply to all test levels in the testing pyramid
 - **test-completeness-dimensions**: Dimension 8 (AI Test Quality) references these rules
 - **flow-based-testing**: Flow tests must follow mock boundary rules
+
+---
+
+## Version History
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0.0 | 2026-05-04 | Initial standard: hollow test problem, CAN/CANNOT mock tables, detection, anti-patterns, rules summary |
+| 1.1.0 | 2026-07-01 | Added injectable background execution as a seam (parallel to clock injection): CAN-mock row, `Injectable Background Execution` section, `Poll/Sleep for Background Result` anti-pattern, and no-poll/sleep rule (issue #143) |

--- a/core/refactoring-standards.md
+++ b/core/refactoring-standards.md
@@ -2,8 +2,8 @@
 
 > **Language**: English | [繁體中文](../locales/zh-TW/core/refactoring-standards.md)
 
-**Version**: 2.1.0
-**Last Updated**: 2026-01-29
+**Version**: 2.2.0
+**Last Updated**: 2026-07-01
 **Applicability**: All software projects undertaking code improvement initiatives
 **Scope**: partial
 **Industry Standards**: ISO/IEC 25010 Maintainability
@@ -98,8 +98,11 @@ This standard defines comprehensive guidelines for code refactoring, covering ev
 |--------|--------|------|
 | **Cyclomatic Complexity** | < 10 per function | Static analysis |
 | **Cognitive Complexity** | Lower is better | SonarQube |
-| **Code Duplication** | < 3% | Static analysis |
+| **Code Duplication (textual)** | < 3% | Static analysis |
+| **Semantic Duplication** | 0 unmanaged domain facts | Golden / architecture test (see below) |
 | **Test Coverage** | ≥ 80% | Coverage tools |
+
+> **Textual vs. semantic duplication**: The `Code Duplication` metric only detects *textual* duplication (near-identical token sequences). It cannot detect *semantic* duplication — the same domain fact re-implemented in several places, or a derived aggregate persisted without an enforced binding to its source. Copies that are not byte-for-byte identical (paraphrased logic, a formula that is right in one place and wrong in another) pass static analysis while still drifting apart. Semantic duplication must be governed by golden tests and architecture tests (see [Semantic Duplication & Copy-Drift](#semantic-duplication--copy-drift)), not by the static-analysis threshold above.
 
 ### ISO/IEC 25010 Maintainability Goals
 
@@ -110,6 +113,41 @@ This standard defines comprehensive guidelines for code refactoring, covering ev
 | **Analysability** | Cyclomatic Complexity | Simplify logic |
 | **Modifiability** | Cohesion, Test Coverage | Single Responsibility |
 | **Testability** | Branch Coverage | Dependency Injection |
+
+---
+
+## Semantic Duplication & Copy-Drift
+
+Textual-duplication metrics catch copy-paste, but they miss the more dangerous case: the **same domain fact implemented in more than one place**. When those implementations are not byte-identical — a paraphrased classification, a formula that is correct in one call site and subtly wrong in another, a total that is stored separately from the rows it summarizes — they pass static analysis and then **drift apart independently**, producing bugs that look unrelated but share a single root cause.
+
+### Anti-pattern: Copy-Drift
+
+Copy-Drift occurs when either:
+
+- A single domain fact (a classification, a rule, a calculation) is **re-implemented at multiple call sites** instead of being computed by one shared unit; or
+- A **derived value is persisted** (a stored aggregate, counter, or denormalized field) **without an enforced relationship to its source**, so each write path can update it independently.
+
+Because the copies are not literally identical, textual-duplication tooling reports nothing. The divergence surfaces later as inconsistency: a list view disagreeing with a detail view, a stored counter double-counting because one update path's decrement branch was commented out, or the same formula giving different answers in different modules.
+
+### Pattern: Single Source of Truth / Derive-Don't-Duplicate
+
+- **One unit per fact.** Extract each domain fact into a **single** classifier / calculator / resolver. Every call site calls it — no re-implementations, no paraphrases.
+- **Derive, don't store.** Prefer computing the value on read over persisting a second copy. A value that is always derived cannot drift.
+- **If an aggregate must be stored**, treat it as a **projection of its detail rows**, and recompute it at a **single choke point** — for example a `SaveChanges` interceptor, or one shared `recompute()` function — so that *every* write path (including async jobs and failure write-backs) goes through the same recomputation and stays consistent. **Never** let an individual path apply an incremental `col = col + delta` adjustment to a stored aggregate; incremental adjustments are exactly how decrement/rollback branches get skipped and counters diverge.
+- **Lock it with tests.** Use a **golden test** to pin the single source of truth, and add an **architecture test** that fails if the rule is redefined anywhere else, so a future copy is rejected at CI rather than discovered in production.
+
+### Migration Corollary — Intentional-Divergence Registry
+
+When a new system **intentionally** diverges from legacy behavior, record it — otherwise a later "fix" will silently revert it. A common case during a port: a legacy *function* returns X, but the legacy *pipeline* downstream reconciles it to Y; the port folds that reconciliation into the single unit so the function now returns Y directly.
+
+- Register each intentional divergence in an **intentional-divergence registry** (legacy behavior, new behavior, rationale, owning fact).
+- Pin the new behavior with a **golden test** so a future "correction" back to legacy fails the build.
+- Feed the registry into any **differential test** against legacy so the divergence is treated as *expected*, not flagged as a regression.
+
+### Note for Adopters
+
+- Per-function legacy-vs-new diffing produces **candidates, not verdicts**. Every candidate must be adjudicated against the **entire** legacy pipeline (not just the one function) before it can be called a bug — the legacy pipeline may already reconcile the apparent difference downstream.
+- Extract legacy function bodies **programmatically / token-based** (not by hand) so you do not reintroduce transcription errors while investigating transcription errors.
 
 ---
 
@@ -157,6 +195,8 @@ This standard defines comprehensive guidelines for code refactoring, covering ev
 ## Related Standards
 
 - [Test-Driven Development](test-driven-development.md) - TDD cycle including refactoring phase
+- [Testing Standards](testing-standards.md) - Golden tests and architecture tests for locking a single source of truth
+- [Test Governance](test-governance.md) - Governing semantic-duplication and intentional-divergence checks in CI
 - [Code Review Checklist](code-review-checklist.md) - Refactoring PR review guidelines
 - [Commit Message Guide](commit-message-guide.md) - `refactor` commit type
 - [Code Check-in Standards](checkin-standards.md) - Pre-commit requirements
@@ -167,6 +207,7 @@ This standard defines comprehensive guidelines for code refactoring, covering ev
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2.2.0 | 2026-07-01 | Added Semantic Duplication & Copy-Drift (issue #142): Copy-Drift anti-pattern, Single Source of Truth / Derive-Don't-Duplicate pattern, Intentional-Divergence Registry migration corollary; split duplication metric into textual vs. semantic |
 | 2.1.0 | 2026-01-29 | Refactored: Split into Rules + Guide, moved detailed patterns to guide |
 | 2.0.0 | 2026-01-21 | Major restructure: Added tactical strategies, Anti-Corruption Layer |
 | 1.0.0 | 2026-01-12 | Initial refactoring standards definition |

--- a/core/versioning.md
+++ b/core/versioning.md
@@ -2,8 +2,8 @@
 
 > **Language**: English | [繁體中文](../locales/zh-TW/core/versioning.md)
 
-**Version**: 1.4.0
-**Last Updated**: 2026-06-24
+**Version**: 1.5.0
+**Last Updated**: 2026-07-01
 **Applicability**: All software projects with versioned releases
 **Scope**: universal
 **Industry Standards**: Semantic Versioning 2.0.0
@@ -206,7 +206,8 @@ alone — the failure mode above *is* a forgotten manual bump. Any of these sati
 - **Git-height–derived versioning** (MinVer / Nerdbank.GitVersioning / GitVersion):
   the version is derived from git commit topology, so a collision is structurally
   impossible. RECOMMENDED for polyglot / .NET / JVM projects (the Automation Tools
-  section is otherwise Node-centric). Note caveats for monorepos and squash-merge
+  section is otherwise Node-centric) — see the git-height subsection under
+  [Automation Tools](#automation-tools). Note caveats for monorepos and squash-merge
   workflows.
 - **A CI uniqueness gate**: fail the release if the computed version already exists
   as a git tag or in the registry.
@@ -220,13 +221,26 @@ and forbidding tag/version reuse — **belong with container-image-standards** a
 specified there; this standard only requires that the version identity itself remain
 unique and immutable.
 
-### Build identity is observable (cross-reference)
+### Build identity is observable (requirement)
 
-A deployed service SHOULD expose `version + commit sha + build time` so operators can tell
-what is running without commit archaeology; when exposed, the sha MUST match the deployed
-artifact's sha (verifiable, not self-reported) and the endpoint SHOULD be access-controlled
-(a public one leaks internal commit identity). This is a deployment / observability
-concern: the build-identity verification requirement **belongs with deployment-standards**
+**A deployed service MUST expose its build identity — `version + commit sha + build time` —
+through a queryable endpoint** (a dedicated `/version`, or embedded in `/health`), so
+operators can determine exactly what is running without inspecting the binary or resorting to
+commit archaeology. Rationale: manual version numbers can collide (above), so ops needs the
+`sha` to tell apart two builds that ship under the same `X.Y.Z`.
+
+Requirements:
+
+- The exposed `sha` MUST match the deployed artifact's sha — it is **verifiable, not
+  self-reported** (derive it from the build, do not hand-type it).
+- The endpoint SHOULD be access-controlled; a public build-identity endpoint leaks internal
+  commit identity.
+- Post-release verification MUST assert the returned sha equals the deployed artifact's sha
+  (see [Phase 5: Post-release Verification](#phase-5-post-release-verification)), not merely
+  that the version number is correct.
+
+This is a deployment / observability concern: the concrete verification *mechanism* (how the
+endpoint is scraped and the assertion wired into a gate) **belongs with deployment-standards**
 (to be specified there), and **supply-chain-attestation** already provides provenance as
 the cryptographic backing for "this artifact came from this sha".
 
@@ -505,8 +519,10 @@ sudo ./upgrade.sh
 # 1. Check service status
 systemctl status your-service
 
-# 2. Check application version
-curl http://localhost:PORT/api/version
+# 2. Check application build identity (version + commit sha + build time)
+#    Assert the returned sha matches the deployed artifact's sha — not just the version.
+curl http://localhost:PORT/version    # or /health, if build identity is embedded there
+# Expected: {"version": "1.2.1", "sha": "<deployed-artifact-sha>", "buildTime": "..."}
 
 # 3. Check logs for no errors
 tail -100 /path/to/app.log | grep -i error
@@ -514,7 +530,9 @@ tail -100 /path/to/app.log | grep -i error
 
 **Success Criteria**:
 - Service running normally
-- API returns correct version number
+- `/version` (or `/health`) returns the correct version number **and** a commit sha that
+  matches the deployed artifact — a matching version alone is insufficient, since two builds
+  can share one `X.Y.Z` (see [Build identity is observable](#build-identity-is-observable-requirement))
 - No fatal errors in logs
 - Functionality verification passed
 
@@ -669,6 +687,32 @@ npm install --save-dev semantic-release
 }
 ```
 
+### Git-height–derived versioning (polyglot: .NET / JVM / multi-language)
+
+The tools above are Node/npm-centric. For **.NET, JVM, or multi-language projects**, prefer
+**git-height–derived versioning**, where the version is computed automatically from the git
+tag graph plus the number of commits since the last tag ("commit height") rather than stored
+in a hand-edited file. Because the version is a deterministic function of git history,
+**two different builds cannot collide on the same version number** and no manual bump step
+can be forgotten — this is what makes it satisfy
+[Deployment Version Identity](#deployment-version-identity) structurally rather than by
+discipline.
+
+| Tool | Ecosystem | Notes |
+|------|-----------|-------|
+| **MinVer** | .NET / MSBuild | Derives the version from the nearest git tag plus commit height; no config file, no build server integration required |
+| **Nerdbank.GitVersioning** (nbgv) | .NET (also Node and others) | Reads a `version.json`; stamps version + git height + commit id into assemblies and packages |
+| **GitVersion** | Polyglot (.NET, plus a language-agnostic CLI) | Configurable versioning modes (e.g. Mainline, Continuous Delivery / Continuous Deployment) driven by branch and tag topology |
+
+**When to use which:**
+
+- **Node / npm projects** → commit-driven automation (`semantic-release` / `standard-version`, above): the bump is derived from Conventional Commits.
+- **Polyglot / .NET / JVM projects** → git-height–derived tools (MinVer / Nerdbank.GitVersioning / GitVersion): the version is derived from git tag + commit height.
+
+Both families remove the forgettable manual bump. **Caveats:** in a monorepo a single
+repo-wide commit height may not map cleanly onto per-package versions, and squash-merge
+workflows alter commit height — validate the derived version against your tagging convention.
+
 ---
 
 ## Dependency Version Ranges
@@ -818,6 +862,7 @@ semver.major('2.3.1');  // 2
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.5.0 | 2026-07-01 | Added: git-height–derived versioning tools (MinVer / Nerdbank.GitVersioning / GitVersion) for polyglot / .NET / JVM projects in Automation Tools (UDS #138 R2); elevated "Build identity is observable" to a requirement — deployed services MUST expose `version + commit sha + build time` via a queryable endpoint — and added a commit-sha + build-time assertion to Phase 5 Post-release Verification (UDS #138 R3) |
 | 1.4.0 | 2026-06-24 | Moved out (to single sources): API Versioning Strategies (de-duplicated), Deprecation Timeline + per-tier periods, Backward Compatibility Checklist, and the Migration Guide template — now owned by api-design-standards / deprecation-standards; versioning cross-references them (XSPEC-298 R8, UDS #126) |
 | 1.3.0 | 2026-06-23 | Added: Deployment Version Identity section; build-metadata-as-deployment-discriminator caveat (from UDS #138) |
 | 1.2.0 | 2025-12-30 | Added: API Versioning Strategies, Deprecation Timeline, Backward Compatibility Checklist |

--- a/locales/zh-TW/core/mock-boundary.md
+++ b/locales/zh-TW/core/mock-boundary.md
@@ -1,8 +1,8 @@
 ---
 source: ../../../core/mock-boundary.md
-source_version: 1.0.0
-translation_version: 1.0.0
-last_synced: 2026-06-10
+source_version: 1.1.0
+translation_version: 1.1.0
+last_synced: 2026-07-01
 source_hash: d2648ad3d869
 status: current
 ---
@@ -11,8 +11,8 @@ status: current
 
 > **Language**: [English](../../../core/mock-boundary.md) | 繁體中文
 
-**版本**: 1.0.0
-**最後更新**: 2026-05-04
+**版本**: 1.1.0
+**最後更新**: 2026-07-01
 **適用範圍**: 所有具備單元測試與整合測試的軟體專案
 **Scope**: universal
 **產業標準**: ISTQB Foundation（Test Doubles）, xUnit Patterns（Gerard Meszaros）
@@ -55,6 +55,7 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 | 環境變數 | `process.env.NODE_ENV`、`process.env.LICENSE_KEY` | 支援組態變化 |
 | 檔案系統（僅限單元測試） | `fs.readFile`、`fs.writeFile` | 讓快速單元測試避免 I/O |
 | 跨模組邊界（須有對應 IT） | 其他模組的 public API | 隔離受測單元 |
+| 行程內背景執行（透過可注入 runner） | `Task.Run`、unawaited promise、`setTimeout`、goroutine、thread-pool dispatch | 注入 runner seam 讓測試能 await 到確定完成，消除 race |
 
 ---
 
@@ -66,6 +67,46 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 | IT/flow/E2E 測試中的資料庫 | 在整合測試中 `vi.mock('./db/client.js')` | 隱藏查詢 bug、schema 問題 |
 | HTTP 框架內部 | `vi.mock('express')` | 真實路由可能已壞 |
 | 安全控制 | 永遠通過的 auth middleware stub | 安全性回歸不可見 |
+
+---
+
+## 可注入的背景執行（Injectable Background Execution）
+
+fire-and-forget 的背景工作（`Task.Run`、unawaited promise、`setTimeout`、goroutine、`java.util.concurrent` executor 提交，或 `asyncio.create_task`）是一個 **seam**，就跟系統時鐘一樣。正如你注入 clock 而非讀取 wall-clock 時間，你也應注入背景 dispatcher，而非直接生出背景工作。這讓測試能把工作驅動到**確定、可被 await 的完成**，並斷言其結果（成功、例外或 retry）——不用 poll、不用 sleep、沒有 race。
+
+把 dispatch 抽象成一個小介面（例如 `IBackgroundTaskRunner` / `BackgroundDispatcher`），再提供兩種實作：
+
+- **Production**：保留真正的 fire-and-forget 語意——dispatch 立即回傳，工作以 detached 方式執行。
+- **Test**：以 **inline** 方式執行工作並**追蹤底層 Task/promise**，對外暴露一個 handle 讓測試能 `await`，使完成（與任何失敗）可被觀察。
+
+語言中立示意（TypeScript pseudo-code）：
+
+```typescript
+// Seam — 於任何 dispatch 背景工作處注入
+interface BackgroundDispatcher {
+  dispatch(work: () => Promise<void>): void
+}
+
+// Production：真正的 fire-and-forget——立即回傳，工作以 detached 執行
+class FireAndForgetDispatcher implements BackgroundDispatcher {
+  dispatch(work: () => Promise<void>): void {
+    void work() // 刻意不 await
+  }
+}
+
+// Test：inline 執行 + 追蹤 task，讓測試能 await 到完成
+class DeterministicDispatcher implements BackgroundDispatcher {
+  private readonly tasks: Promise<void>[] = []
+  dispatch(work: () => Promise<void>): void {
+    this.tasks.push(work()) // inline 啟動並保留 handle
+  }
+  async settle(): Promise<void> {
+    await Promise.all(this.tasks) // 測試 await 到確定完成
+  }
+}
+```
+
+測試注入 `DeterministicDispatcher`，執行受測程式碼，再於斷言結果前 `await dispatcher.settle()`——背景副作用此時已完全可觀察且具確定性。
 
 ---
 
@@ -87,6 +128,7 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 - **Orphan Mock**：跨模組 mock 卻沒有對應的整合測試
 - **Security Bypass Mock**：auth/權限邏輯被換成直接放行的 stub
 - **Database Mock Cascade**：DB 回傳寫死的資料，隱藏真實查詢錯誤
+- **Poll/Sleep for Background Result**：用 sleep 或 poll 等待 fire-and-forget 背景工作完成。race 依然存在——timeout 只是多數時候把它遮住，同時拖慢整套測試；在共用 runner 上更會把 flakiness 洩漏進其他 MR 的 CI。改注入 deterministic runner 並 await 被追蹤的 task。
 
 ---
 
@@ -99,6 +141,7 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 | IT 對應測試 | mock 跨模組邊界 | 確保有對應的 IT 存在 |
 | 禁止 mock 安全機制 | 測試涉及 auth/權限 | 使用真實測試使用者 + 真實 token |
 | 空心審查 | Mock 數量 ≥ import 數量 | 加入輸出值斷言 |
+| 背景工作禁止 poll/sleep | 測試斷言某個 fire-and-forget 副作用 | 注入 deterministic runner；await 被追蹤的 task |
 
 ---
 
@@ -107,3 +150,12 @@ vi.mock('node:fs/promises', ...)                  // I/O replaced
 - **testing**：Mock 邊界規則適用於測試金字塔的所有測試層級
 - **test-completeness-dimensions**：維度 8（AI 測試品質）引用了這些規則
 - **flow-based-testing**：Flow 測試必須遵循 mock 邊界規則
+
+---
+
+## 版本歷史
+
+| 版本 | 日期 | 變更 |
+|------|------|------|
+| 1.0.0 | 2026-05-04 | 初始標準：空心測試問題、可／不可 Mock 表格、偵測、反模式、規則摘要 |
+| 1.1.0 | 2026-07-01 | 新增可注入的背景執行作為 seam（平行於 clock injection）：可 Mock 表列、`可注入的背景執行` 章節、`Poll/Sleep for Background Result` 反模式，以及背景工作禁止 poll/sleep 規則（issue #143） |

--- a/locales/zh-TW/core/refactoring-standards.md
+++ b/locales/zh-TW/core/refactoring-standards.md
@@ -1,8 +1,8 @@
 ---
 source: ../../../core/refactoring-standards.md
-source_version: 2.1.0
-translation_version: 2.1.0
-last_synced: 2026-04-22
+source_version: 2.2.0
+translation_version: 2.2.0
+last_synced: 2026-07-01
 status: current
 ---
 
@@ -10,8 +10,8 @@ status: current
 
 > **語言**: [English](../../../core/refactoring-standards.md) | 繁體中文
 
-**版本**: 2.1.0
-**最後更新**: 2026-02-10
+**版本**: 2.2.0
+**最後更新**: 2026-07-01
 **適用性**: 所有軟體專案
 **範圍**: 通用 (Universal)
 
@@ -64,10 +64,46 @@ status: current
 
 ---
 
+## 語意重複與 Copy-Drift（語意重複）
+
+文字重複（textual duplication）指標只能抓到逐字複製，卻抓不到更危險的情況：**同一個 domain fact 在多處被重複實作**。當這些實作不是逐字相同時（改寫過的分類邏輯、同一條公式在一處對一處錯、把 total 與它彙總的 rows 分開儲存），它們會通過靜態分析，然後**各自獨立地漂移**，產生看似無關、實則同源的一叢 bug。
+
+### 反模式：Copy-Drift
+
+Copy-Drift 發生於下列任一情況：
+
+- 單一 domain fact（分類、規則、計算）被**在多個 call site 重複實作**，而非由單一共用單元計算；或
+- **derived value 被持久化**（stored aggregate、counter、denormalized 欄位）**卻無與來源綁定的強制關係**，使每條 write path 都能各自更新它。
+
+因為這些 copy 並非逐字相同，文字重複工具一個都抓不到。漂移會在稍後以不一致的形式浮現：list view 與 detail view 對不上、stored counter 因某條更新路徑的 decrement/rollback 分支被略過或被註解掉而重複計數、或同一條公式在不同模組給出不同答案。
+
+### 模式：Single Source of Truth / Derive-Don't-Duplicate
+
+- **每個 fact 只有一個單元**：把每個 domain fact 抽成**唯一**的 classifier / calculator / resolver；所有 call site 都呼叫它——不重實作、不改寫。
+- **優先 derive，不要 store**：優先在 read 時計算，而非持久化第二份 copy；永遠被 derive 的值不會漂移。
+- **若 aggregate 一定要存**，把它當成 detail rows 的 **projection**，並在**單一 choke point**（例如 `SaveChanges` interceptor，或單一共用 `recompute()` 函式）重算，讓**每一條** write path（含 async job 與 failure write-back）都走同一個重算路徑而保持一致。**絕不**讓個別 path 對 stored aggregate 做 incremental `col = col + delta` 調整；incremental 調整正是 decrement/rollback 分支被略過、counter 發生漂移的原因。
+- **用測試鎖定**：用 **golden test** 鎖定 single source of truth，並加一個 **architecture test**——若規則在別處被重新定義就 fail，讓未來的 copy 在 CI 被擋下，而非在 production 才發現。
+
+### 遷移推論——Intentional-Divergence Registry（刻意偏離登記）
+
+當新系統**刻意**偏離 legacy 行為時，必須登記——否則未來某次「修正」會靜默地把它回退掉。port 過程中常見的情況：legacy *函式*回傳 X，但 legacy *pipeline* 在下游把它調和成 Y；port 把這個調和折進單一單元，讓函式直接回傳 Y。
+
+- 把每個刻意偏離登記在 **intentional-divergence registry**（legacy 行為、new 行為、rationale、所屬 fact）。
+- 用 **golden test** 鎖定 new 行為，讓未來「修正」回 legacy 會讓 build fail。
+- 把 registry 餵給對 legacy 的任何 **differential test**，使該偏離被視為**預期**而非 regression。
+
+### 給採用者的註記
+
+- per-function 的 legacy-vs-new diffing 只產出**候選**，非裁決；每個候選都要對照**整條** legacy pipeline（下游可能已調和該差異）裁決後，才能稱為 bug。
+- 用 programmatic / token-based 方式抽取 legacy 函式本體（不要手抄），避免在調查抄寫錯誤時又重新引入抄寫錯誤。
+
+---
+
 ## 相關標準
 
 - [重構指南](guides/refactoring-guide.md) - 詳細模式與教學
-- [測試標準](testing-standards.md)
+- [測試標準](testing-standards.md) - golden test 與 architecture test 鎖定 single source of truth
+- [測試治理](test-governance.md) - 在 CI 治理語意重複與 intentional-divergence 檢查
 - [程式碼審查清單](code-review-checklist.md)
 
 ---
@@ -76,6 +112,7 @@ status: current
 
 | 版本 | 日期 | 變更 |
 |------|------|------|
+| 2.2.0 | 2026-07-01 | 新增「語意重複與 Copy-Drift」（issue #142）：Copy-Drift 反模式、Single Source of Truth / Derive-Don't-Duplicate 模式、Intentional-Divergence Registry 遷移推論。 |
 | 2.0.0 | 2026-01-29 | **重大重構**：拆分為規則（本文件）和指南（refactoring-guide.md）。 |
 | 1.0.0 | 2025-12-15 | 初始版本 |
 

--- a/locales/zh-TW/core/versioning.md
+++ b/locales/zh-TW/core/versioning.md
@@ -1,8 +1,8 @@
 ---
 source: ../../../core/versioning.md
-source_version: 1.4.0
-translation_version: 1.4.0
-last_synced: 2026-06-24
+source_version: 1.5.0
+translation_version: 1.5.0
+last_synced: 2026-07-01
 status: current
 ---
 
@@ -10,8 +10,8 @@ status: current
 
 # 語義化版本標準
 
-**版本**: 1.3.0
-**最後更新**: 2026-06-23
+**版本**: 1.5.0
+**最後更新**: 2026-07-01
 **適用範圍**: 所有有版本發布的軟體專案
 
 ---
@@ -199,7 +199,8 @@ Format: `MAJOR.MINOR.PATCH+BUILD`
   在 CI 中由 commit 歷史推導並 bump 版本，使人無從忘記 bump。
 - **git-height 衍生版本**（MinVer / Nerdbank.GitVersioning / GitVersion）：版本由 git 提交拓撲
   推導，故碰撞結構上不可能。對 polyglot / .NET / JVM 專案 RECOMMENDED（自動化工具一節原本以 Node
-  為主）。注意 monorepo 與 squash-merge 工作流的注意事項。
+  為主）——見 [自動化工具](#自動化工具) 下的 git-height 子節。注意 monorepo 與 squash-merge 工作流
+  的注意事項。
 - **CI 唯一性閘**：若算出的版本已存在於 git tag 或 registry，則 release 失敗。
 
 ### 不可變 artifact（交叉引用）
@@ -208,11 +209,21 @@ Format: `MAJOR.MINOR.PATCH+BUILD`
 而非可變 tag）。具體的 artifact 層級要求——把部署釘在內容位址、禁止 tag/版本重用——**歸
 container-image-standards** 且將於該標準訂定；本標準只要求版本身分本身保持唯一且不可變。
 
-### Build 身分可被觀測（交叉引用）
+### Build 身分可被觀測（需求）
 
-已部署的服務 SHOULD 暴露 `version + commit sha + build time`，讓維運者不必 commit 考古就能知道在跑
-什麼；一旦暴露，sha MUST 與已部署 artifact 的 sha 相符（可驗證、非自述），且該端點 SHOULD 受存取
-控制（公開端點會洩漏內部 commit 身分）。這是部署 / 可觀測性的關切：build 身分驗證的要求**歸
+**已部署的服務 MUST 透過可查詢的 endpoint（專用的 `/version`，或嵌入 `/health`）暴露其 build 身分
+——`version + commit sha + build time`**，讓維運者不必檢視二進位或做 commit 考古就能知道確切在跑
+什麼。理由：手動版本號可能碰撞（如上），所以 ops 需要 `sha` 才能區分共用同一個 `X.Y.Z` 的兩個 build。
+
+需求：
+
+- 暴露的 `sha` MUST 與已部署 artifact 的 sha 相符——是**可驗證、非自述**（由建置推導，不可手打）。
+- 該 endpoint SHOULD 受存取控制；公開的 build 身分 endpoint 會洩漏內部 commit 身分。
+- 部署後驗證 MUST 斷言回傳的 sha 等於已部署 artifact 的 sha
+  （見 [Phase 5: Post-release Verification](#phase-5-post-release-verification-驗證階段)），而非僅
+  斷言版本號正確。
+
+這是部署 / 可觀測性的關切：具體的驗證*機制*（如何抓取 endpoint 並把斷言接進 gate）**歸
 deployment-standards**（將於該標準訂定），而 **supply-chain-attestation** 已提供 provenance 作為
 「此 artifact 確實來自此 sha」的密碼學背書。
 
@@ -491,8 +502,10 @@ sudo ./upgrade.sh
 # 1. 檢查服務狀態
 systemctl status your-service
 
-# 2. 檢查應用程式版本
-curl http://localhost:PORT/api/version
+# 2. 檢查應用程式 build 身分（version + commit sha + build time）
+#    斷言回傳的 sha 與已部署 artifact 的 sha 相符——不只是版本號。
+curl http://localhost:PORT/version    # 或 /health（若 build 身分嵌入其中）
+# 預期: {"version": "1.2.1", "sha": "<deployed-artifact-sha>", "buildTime": "..."}
 
 # 3. 檢查日誌無錯誤
 tail -100 /path/to/app.log | grep -i error
@@ -500,7 +513,9 @@ tail -100 /path/to/app.log | grep -i error
 
 **成功標準**:
 - 服務正常運行
-- API 回應正確版本號
+- `/version`（或 `/health`）回應正確版本號**且**回傳與已部署 artifact 相符的 commit sha——
+  僅版本號相符並不足夠，因為兩個 build 可能共用同一個 `X.Y.Z`
+  （見 [Build 身分可被觀測](#build-身分可被觀測需求)）
 - 日誌無致命錯誤
 - 功能驗證通過
 
@@ -655,6 +670,29 @@ npm install --save-dev semantic-release
 }
 ```
 
+### git-height 衍生版本（polyglot：.NET / JVM / 多語言）
+
+上述工具以 Node/npm 為主。對 **.NET、JVM 或多語言專案**，優先採用 **git-height 衍生版本**：
+版本由 git tag 圖加上「自上一個 tag 以來的 commit 數（commit height）」自動計算，而非存在
+人工編輯的檔案中。由於版本是 git 歷史的確定性函數，**兩個不同的建置不可能碰撞到同一個版本號**，
+且沒有任何手動 bump 步驟會被忘記——這正是它從結構上（而非靠紀律）滿足
+[部署版本身分](#部署版本身分)的原因。
+
+| Tool | Ecosystem | 說明 |
+|------|-----------|------|
+| **MinVer** | .NET / MSBuild | 由最近的 git tag 加 commit height 推導版本；無需設定檔、無需 build server 整合 |
+| **Nerdbank.GitVersioning** (nbgv) | .NET（也支援 Node 等） | 讀取 `version.json`；將 version + git height + commit id 烙印進 assembly 與套件 |
+| **GitVersion** | Polyglot（.NET，加上語言無關的 CLI） | 可設定的版本模式（如 Mainline、Continuous Delivery / Continuous Deployment），由分支與 tag 拓撲驅動 |
+
+**如何選擇：**
+
+- **Node / npm 專案** → commit 驅動的自動化（`semantic-release` / `standard-version`，見上）：bump 由 Conventional Commits 推導。
+- **Polyglot / .NET / JVM 專案** → git-height 衍生工具（MinVer / Nerdbank.GitVersioning / GitVersion）：版本由 git tag + commit height 推導。
+
+兩類都消除了會被忘記的手動 bump。**注意事項：** 在 monorepo 中，單一 repo 範圍的 commit height
+未必能乾淨對應到各套件的版本，而 squash-merge 工作流會改變 commit height——請對照你的 tagging
+慣例驗證推導出的版本。
+
 ---
 
 ## 依賴版本範圍
@@ -804,6 +842,7 @@ semver.major('2.3.1');  // 2
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.5.0 | 2026-07-01 | Added: 自動化工具新增 git-height 衍生版本工具（MinVer / Nerdbank.GitVersioning / GitVersion），適用 polyglot / .NET / JVM 專案（UDS #138 R2）；將「Build 身分可被觀測」提升為需求——已部署服務 MUST 透過可查詢 endpoint 暴露 `version + commit sha + build time`——並於 Phase 5 部署後驗證新增 commit-sha + build-time 斷言（UDS #138 R3） |
 | 1.4.0 | 2026-06-24 | Moved out (to single sources): API Versioning Strategies (de-duplicated), Deprecation Timeline + per-tier periods, Backward Compatibility Checklist, Migration Guide template — now owned by api-design-standards / deprecation-standards (XSPEC-298 R8, UDS #126) |
 | 1.3.0 | 2026-06-23 | Added: Deployment Version Identity section; build-metadata-as-deployment-discriminator caveat (from UDS #138) |
 | 1.2.0 | 2025-12-30 | Added: API Versioning Strategies, Deprecation Timeline, Backward Compatibility Checklist |


### PR DESCRIPTION
三項事故導出的標準新增，均完成三方同步（core `.md` + `ai/standards/*.ai.yaml` + zh-TW 鏡像），三方同步 gate 全綠（translation-sync 0 MAJOR/0 missing、registry completeness、reference-sync）。

- **versioning 1.4.0 → 1.5.0（#138 R2/R3）**：git-height 版本推導工具（MinVer / Nerdbank.GitVersioning / GitVersion）補足 Node-only 缺口；build identity 升為需求（`/version`｜`/health` 暴露 version+sha+build time，Phase 5 驗證斷言 sha 相符）。
- **refactoring-standards 2.1.0 → 2.2.0（#142）**：語意重複 & Copy-Drift 反模式 + Single-Source-of-Truth / Derive-Don't-Duplicate 解法 + 遷移 Intentional-Divergence Registry。
- **mock-boundary 1.0.0 → 1.1.0（#143）**：行程內 fire-and-forget 背景執行作為可注入的 seam（如同 clock injection）+ Poll/Sleep 反模式 + 禁止 poll/sleep 規則。

Closes #138
Closes #142
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
