### PR TITLE
docs: add section separator above Acknowledgments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
 | **Documentation** | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
 | **CLI Tool** | [MIT](cli/LICENSE) |
 
+---
+
 ## Acknowledgments
 
 UDS draws architectural inspiration from these outstanding open-source projects:


### PR DESCRIPTION
Improves README visual consistency by adding a section divider (`---`) above the Acknowledgments heading, matching the styling of preceding sections.